### PR TITLE
Added information about Clamp Dissolve

### DIFF
--- a/docs/special-fx/dissolve.md
+++ b/docs/special-fx/dissolve.md
@@ -154,6 +154,16 @@ The 3D Point to start the dissolve at. For avatars, this should be set far enoug
 
 The 3D Point to end the dissolve at. For avatars, this should be set far enough away that changes in skinning (sticking arms/legs out) don't cause the dissolve to unintentionally trigger.
 
+### Clamp Dissolve
+
+`Type`: **Checkbox**
+
+If set to True, this ensures that the whole material is clamped to the set value. This means if the dissolve Alpha is at `1` or `0`, they will never be partially dissolved or not dissolved. This can fix issues where portions of your Material are not completely Dissolved or Visible, particularly with your Model's Scale.
+
+:::tip 
+It may be benificial to enable this option if you change your Avatar's Scale frequently in-game. This will help prevent Dissolves from partially working as intended at various heights or scales. 
+:::
+
 ## Hue Shift
 
 Enables/Disables hue shifting features for dissolve. Unlike most sections, this checkbox can be animated.

--- a/docs/special-fx/dissolve.md
+++ b/docs/special-fx/dissolve.md
@@ -158,10 +158,10 @@ The 3D Point to end the dissolve at. For avatars, this should be set far enough 
 
 `Type`: **Checkbox**
 
-If set to True, this ensures that the whole material is clamped to the set value. This means if the dissolve Alpha is at `1` or `0`, they will never be partially dissolved or not dissolved. This can fix issues where portions of your Material are not completely Dissolved or Visible, particularly with your Model's Scale.
+If set to True, this ensures that the whole material is clamped to the set value. This means if the dissolve Alpha is at `1` or `0`, they will never be partially dissolved or partially visible. This can fix issues where portions of your Material have visibility issues at certain poses with those values.
 
 :::tip 
-It may be benificial to enable this option if you change your Avatar's Scale frequently in-game. This will help prevent Dissolves from partially working as intended at various heights or scales. 
+It may be benificial to enable this option if you change your Avatar's Scale frequently in VRChat, as it will help prevent Dissolves from partially working as intended at various heights or scales. 
 :::
 
 ## Hue Shift


### PR DESCRIPTION
There is no mention of this anywhere in this page, so I decided to write it in. Since VRChat implemented the ability to directly change your Avatar's Scale in-game, it is known that Scale can greatly affect how Dissolves behave depending on if Clamping is on or off.

I feel it would be very helpful to document this now since I've seen this being a common question everywhere I go.

Feedback on my wording of this is greatly appreciated!