### PR TITLE
Added `playsinline='true'` attribute to PoiVideo.js. Fixes Issue #26

### DIFF
--- a/src/components/PoiVideo.js
+++ b/src/components/PoiVideo.js
@@ -3,6 +3,6 @@ import ReactPlayer from 'react-player'
 
 export default function PoiVideo({url}) {
 	return (
-		<ReactPlayer playing controls="false" muted loop='true' url={url} />
+		<ReactPlayer playing controls="false" muted loop='true' playsinline='true' url={url} />
 	);
-  }
+}


### PR DESCRIPTION
Fixed an annoying issue where the embedded React Video Player would constantly pop-up on any page with a `PoiVideo` attachment when viewed on a Mobile Web Browser, such as Safari for iOS.

This fixes Issue #26 