### PR TITLE
Added Backlight Documentation

### DIFF
--- a/docs/shading/backlight.md
+++ b/docs/shading/backlight.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 11
+title: Backlight
+---
+import PoiVideo from '@site/src/components/PoiVideo'
+
+Backlight is a shading feature that is used to express lighting from *behind* a character or model, which can look similar to how Japanese-style illustrations are drawn.
+
+While it may seem similar to some form of Rim Lighting, it's instead rendered quite differently. Lights can receive shadows and follow the light source, which can be effective when the light hits from behind. This feature behaves in a similar fashion to LilToon's Backlighting.
+
+## Color
+
+- `Type`: **HDR Color**
+
+Color of the light background.
+
+## Texture
+
+- `Type`: **Color** Texture (`sRGB: ON`)
+
+Texture that can be used as the Color of the Backlight.
+
+## Main Color Blend
+
+- `Type`: **Float**, Range: `0.0 - 1.0`
+
+How much to blend the color of the Backlight with the Base Color.
+
+## Normal Strength
+
+- `Type`: **Float**, Range: `0.0 - 1.0`
+
+How much to blend the lighting with the Normals on your Model or Material.
+
+## Border
+
+- `Type`: **Float**, Range: `0.0 - 1.0`
+
+The range of light that can be used with the Backlight.
+
+## Blur
+
+- `Type`: **Float**, Range: `0.0 - 1.0`
+
+The amount of blur on the Backlight.
+
+## Directivity
+
+- `Type`: **Float**
+
+Determines the amount of brightness *in degrees* that change according to the direction of the light source.
+
+## View Direction Strength
+
+- `Type`: **Float**, Range: `0.0 - 1.0`
+
+The *degree* to which the brightness is changed according to the direction of light.
+
+## Receive Shadow
+
+- `Type`: **Checkbox**
+
+If enabled, receive Shadows from other objects.
+
+## Backface Mask
+
+- `Type`: **Checkbox**
+
+Enables/Disables the visibility of the backlight's light on the backface.

--- a/docs/shading/ltcgi.md
+++ b/docs/shading/ltcgi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: LTCGI
 ---
 import PoiVideo from '@site/src/components/PoiVideo'

--- a/docs/special-fx/flipbook.md
+++ b/docs/special-fx/flipbook.md
@@ -4,6 +4,14 @@ title: Flipbook
 ---
 import PoiVideo from '@site/src/components/PoiVideo' 
 
+Flipbook is a classic feature that allows images from a Texture Array to be played as an animation on the Material. This can be a way to play GIFs or a specific 2D animation that either animates in a loop or in a specified pattern.
+
+Flipbooks use a `Texture Array`, which is a special type of file that consists of a multiple set of images that are sorted in a specified sequence. They can be created in Unity using ThryEditor TextureArray Utility.
+
+:::caution
+Texture Arrays can quickly add up to your VRAM consumption depending on the resolution and the amount of images used in your array! Please keep this in mind when creating your Texture Arrays.
+:::
+
 ## Flipbook Controls Alpha
 
 - `Type`: **Checkbox**


### PR DESCRIPTION
### New
- Added Backlight Documentation page, located at `./docs/shading/backlight.md`.

### Changed
- Added a description for the Flipbook page since it didn't have one. Also placed a warning about the use of Texture Arrays.