### PR TITLE
Blog Sidebar now shows ALL Posts, instead of the Recent 5

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,6 +113,8 @@ const config = {
 
         blog: {
           showReadingTime: true,
+          blogSidebarTitle: 'All Posts',
+          blogSidebarCount: 'ALL',
           // Please change this to your repo.
           // editUrl:
           // 'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',


### PR DESCRIPTION
Added two parameters to the `docusaurus.config.json`, fixing an issue where some Posts weren't able to be accessed from the Blog Sidebar.