### PR TITLE
Improved clarity. Removed description from "Max Distance Falloff" 

### DIFF
--- a/docs/shading/ssao.md
+++ b/docs/shading/ssao.md
@@ -38,7 +38,7 @@ Determines how intensely AO will be blended.
 
 - `Type`: **Float**, Range: `0.0001 - 0.02`
 
-This controls how far AO shadows can spread out.
+Determines the radius tested for hemispheric visibility check. This controls how far AO shadows can spread out.
 
 ## AO Quality
 

--- a/docs/shading/ssao.md
+++ b/docs/shading/ssao.md
@@ -38,7 +38,7 @@ Determines how intensely AO will be blended.
 
 - `Type`: **Float**, Range: `0.0001 - 0.02`
 
-Determines the radius tested for hemispheric visibility check. This controls how far AO shadows can spread out.
+This controls how far AO shadows can spread out.
 
 ## AO Quality
 
@@ -163,7 +163,7 @@ The distance from the camera, in meters, beyond which AO will be completely disa
 
 - `Type`: **Float2**
 
-Description needed
+Reduce these if your AO looks like it's "reaching too far". X determines the difference in depth (beyond the radius) beyond which AO shadows will begin to attenuate. Y determines the difference in depth (beyond the radius) beyond which AO shadows will completely terminate.
 
 ### Apply From Global Mask
 

--- a/docs/shading/ssao.md
+++ b/docs/shading/ssao.md
@@ -116,10 +116,10 @@ Color Adjust fields for SSAO. Refers to Hue, Saturation, Brightness, and Gamma.
 
 | Channel | Function |
 | --- | --- |
-| H | Hue |
-| S | Saturation |
-| V | Brightness |
-| G | Gamma |
+| X | Hue |
+| Y | Saturation |
+| Z | Value/Brightness |
+| W | Gamma |
 
 ### Color
 

--- a/docs/shading/ssao.md
+++ b/docs/shading/ssao.md
@@ -151,19 +151,19 @@ Stylistically hide SSAO under bright lighting conditions.
 
 - `Type`: **Float**
 
-The Starting Range of the AO Falloff.
+The distance from the camera, in meters, beyond which AO will steadily reduce quality to improve performance.
 
 ### Quality Falloff End
 
 - `Type`: **Float**
 
-The Ending Range of the AO Falloff.
+The distance from the camera, in meters, beyond which AO will be completely disabled to improve performance.
 
 ### Max Distance Falloff
 
 - `Type`: **Float2**
 
-Maximum distance of the AO Falloff.
+Description needed
 
 ### Apply From Global Mask
 


### PR DESCRIPTION
Too vague to be a useful description of its function. Instead we should just mark it as something we need to get back to.