### PR TITLE
Add i18n for future translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log*
 *.code-workspace
 .markdownlint.json
 /.vscode/settings.json
+
+.idea

--- a/docs/audio-link/audio-link.md
+++ b/docs/audio-link/audio-link.md
@@ -24,23 +24,23 @@ If enabled, activates Audio Link features and exposes Audio Link parameter contr
 
 :::info
 When this feature activates, the following sections in Poiyomi Shaders will have their Audio Link properties exposed for you to use. Please refer to each of their Documentation Entries for more information.
-- [Color Adjust](/docs/color-and-normals/color-adjust.md#hue-shift-audio-link)
-- [Alpha Options](/docs/color-and-normals/alpha-options.md#alpha-audio-link)
-- [Decals](/docs/color-and-normals/decals.md#audio-link)
-- [Matcap](/docs/shading/matcap.md#audio-link)
-- [Rim Lighting](/docs/shading/rim-lighting.md#audio-link)
-- [Outlines](/docs/outlines/outlines.md#audio-link)
-- [Dissolve](/docs/special-fx/dissolve.md#audio-link)
-- [Flipbook](/docs/special-fx/flipbook.md#audio-link)
-- [Emission](/docs/special-fx/emission.md#audio-link)
-- [Glitter / Sparkle](/docs/special-fx/glitter.md#audio-link)
-- [Pathing](/docs/special-fx/pathing.md#audio-link)
-- [Voronoi](/docs/special-fx/voronoi.md#audio-link)
-- [Truchet](/docs/special-fx/truchet.md#audio-link)
-- [Constellation](/docs/special-fx/constellation.md#audio-link)
-- [Vertex Options -> Basics & Fun](/docs/vertex-options/basics.md#audio-link)
-- [Vertex Options -> Glitching](/docs/vertex-options/glitching.md#audio-link)
-- [Vertex Options -> LookAt](/docs/vertex-options/look-at.md#audio-link)
+- [Color Adjust](/color-and-normals/color-adjust.md#hue-shift-audio-link)
+- [Alpha Options](/color-and-normals/alpha-options.md#alpha-audio-link)
+- [Decals](/color-and-normals/decals.md#audio-link)
+- [Matcap](/shading/matcap.md#audio-link)
+- [Rim Lighting](/shading/rim-lighting.md#audio-link)
+- [Outlines](/outlines/outlines.md#audio-link)
+- [Dissolve](/special-fx/dissolve.md#audio-link)
+- [Flipbook](/special-fx/flipbook.md#audio-link)
+- [Emission](/special-fx/emission.md#audio-link)
+- [Glitter / Sparkle](/special-fx/glitter.md#audio-link)
+- [Pathing](/special-fx/pathing.md#audio-link)
+- [Voronoi](/special-fx/voronoi.md#audio-link)
+- [Truchet](/special-fx/truchet.md#audio-link)
+- [Constellation](/special-fx/constellation.md#audio-link)
+- [Vertex Options -> Basics & Fun](/vertex-options/basics.md#audio-link)
+- [Vertex Options -> Glitching](/vertex-options/glitching.md#audio-link)
+- [Vertex Options -> LookAt](/vertex-options/look-at.md#audio-link)
 :::
 
 ### Anim Toggle
@@ -50,7 +50,7 @@ When this feature activates, the following sections in Poiyomi Shaders will have
 This checkbox allows toggling Audio Link effects at runtime.
 
 :::tip
-Audio Link is enabled by default. To turn off Audio Link in-game, you need to animate this Toggle (checkbox) when creating toggles for Audio Link on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+Audio Link is enabled by default. To turn off Audio Link in-game, you need to animate this Toggle (checkbox) when creating toggles for Audio Link on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## Smoothing

--- a/docs/color-and-normals/alpha-options.md
+++ b/docs/color-and-normals/alpha-options.md
@@ -6,7 +6,7 @@ image: /img/color-and-normals/Thumb-AlphaOptions.png
 keywords: [alpha, options, properties, poiyomi, shader]
 ---
 
-The **Alpha Options** section provides options for modifying how the material treats alpha. The effects of these options are heavily influenced by the [Render Preset](/docs/general/render-preset.md) and other render settings.
+The **Alpha Options** section provides options for modifying how the material treats alpha. The effects of these options are heavily influenced by the [Render Preset](/general/render-preset.md) and other render settings.
 
 These properties below can allow you to further modify how you want the Alpha to behave on the Shader, like the Fresnel effect, Angular Alpha, Distance Fade, and more.
 
@@ -26,7 +26,7 @@ Alpha Mod defines a direct value to add to or remove from the material alpha. Th
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use for the Alpha overall.
+Select which [Global Mask](/modifiers/global-masks.md) to use for the Alpha overall.
 
 ## Alpha To Coverage
 
@@ -123,7 +123,7 @@ The distance (in meters) at which the Max Distance Alpha multiplier will be appl
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Distance Alpha / Distance Fade onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Distance Alpha / Distance Fade onto.
 
 ## Fresnel Alpha
 
@@ -131,7 +131,7 @@ Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the D
 
 Enable or Disable the Fresnel Alpha effect. Fresnel Alpha uses the angle between the viewer (camera) and the object's normal to modify the alpha.
 
-This can be used to simulate materials that are more opaque at shallow angles, such as transluscent fabric (used for tights or stockings). It can be thought of as analagous to [Rim Lighting](/docs/shading/rim-lighting.md), but for alpha instead of color.
+This can be used to simulate materials that are more opaque at shallow angles, such as transluscent fabric (used for tights or stockings). It can be thought of as analagous to [Rim Lighting](/shading/rim-lighting.md), but for alpha instead of color.
 
 ### Intensity
 
@@ -161,7 +161,7 @@ Whether the Fresnel Alpha effect should increase in intensity from the outside-i
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Fresnel Alpha effect onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Fresnel Alpha effect onto.
 
 ## Angular Alpha
 
@@ -253,7 +253,7 @@ The minimum value of alpha for the Angular Alpha mode. This will prevent the alp
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Angular Alpha effect onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Angular Alpha effect onto.
 
 ## Alpha Audio Link
 
@@ -262,7 +262,7 @@ Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the A
 Enables Audio Link for Alpha Options. The Alpha can be modified based on the audio level in a specific band.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Add Band

--- a/docs/color-and-normals/back-face.md
+++ b/docs/color-and-normals/back-face.md
@@ -10,7 +10,7 @@ Back Face provides options for modifying the base color, emission, and alpha for
 On 3D models, meshes typically only show it's faces on one side, that being the front-facing side. The back-facing side of the mesh is usually see-through, an effect that you can get when you are looking from inside a model. Shaders can control this behavior, forcing the back-facing side of the mesh to also render if the user desires for whatever reason.
 
 :::caution Disable Culling to use this feature!
-To use this section, [Cull](/docs/rendering/rendering.md#cull) must be set to `Off` in order for backfaces to be visible. Find this option under [Rendering](/docs/rendering/rendering.md).
+To use this section, [Cull](/rendering/rendering.md#cull) must be set to `Off` in order for backfaces to be visible. Find this option under [Rendering](/rendering/rendering.md).
 :::
 
 ## Color
@@ -49,7 +49,7 @@ Enable or Disable Hue Shift for the backface base color.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -86,7 +86,7 @@ How much to constantly shift the hue with time. A value of 1 will result in a fu
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `0.0 - 5.0`
 
-Detail Intensity backface multiplier for detail textures in the [Details](/docs/color-and-normals/details.md) section.
+Detail Intensity backface multiplier for detail textures in the [Details](/color-and-normals/details.md) section.
 
 ### Replace Alpha
 
@@ -98,4 +98,4 @@ Whether to replace the alpha value for the backface with the alpha calculated fr
 
 - `Type`: <PropertyIcon name="float" />**Float**
 
-Custom Multiplier to limit the [Emissions](/docs/special-fx/emission.md) shown on the backface.
+Custom Multiplier to limit the [Emissions](/special-fx/emission.md) shown on the backface.

--- a/docs/color-and-normals/color-adjust.md
+++ b/docs/color-and-normals/color-adjust.md
@@ -6,7 +6,7 @@ image: /img/color-and-normals/Thumb-ColorAdjust.png
 keywords: [hue, color, saturation, gamma, hue shift, poiyomi]
 ---
 
-The Color Adjust section provides options for modifying the base color of the material. This is applied directly after the main [Color and Normals](/docs/color-and-normals/color-and-normals.md) section, and will not affect any other sections that modify the Base Color.
+The Color Adjust section provides options for modifying the base color of the material. This is applied directly after the main [Color and Normals](/color-and-normals/color-and-normals.md) section, and will not affect any other sections that modify the Base Color.
 
 Color Adjust can be used to quickly change the colors presented from the main texture to a different hue of color either directly or indirectly. The results of the hue shift can vary depending on which [Color Space](#color-space) is chosen, and how much [Saturation](#saturation), [Brightness](#brightness), and [Gamma](#gamma), is set by the user.
 
@@ -25,7 +25,7 @@ In order to Bake a texture (and enable this button), you must first adjust any o
 
 Texture Slot that defines where to specifically apply the color adjustments to. If this texture is not defined, the adjustments will apply everywhere.
 
-This slot has the [Texture Packer](/docs/thryeditor/thryeditor.md#texture-packer) integrated for convenience.
+This slot has the [Texture Packer](/thryeditor/thryeditor.md#texture-packer) integrated for convenience.
 
 | Channel | Mask |
 | :---: | :---: |
@@ -180,7 +180,7 @@ If set, will constantly shift the hue with time. A value of `1` will result in a
 If enabled, allows the Hue Shift to be controlled with Audio Link chronotensity.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 #### Band
@@ -221,7 +221,7 @@ How strong should the Color Grading be applied to the Color Adjust.
 
 ## Global Mask
 
-Use this section to instead use a [Global Mask](/docs/modifiers/global-masks.md) for the Color Adjust Mask.
+Use this section to instead use a [Global Mask](/modifiers/global-masks.md) for the Color Adjust Mask.
 
 ### Hue
 

--- a/docs/color-and-normals/color-and-normals.md
+++ b/docs/color-and-normals/color-and-normals.md
@@ -61,7 +61,7 @@ The Normal Map texture has a slider for **Intensity**, which affects how much in
 
 *Adjusting the Intensity of a Normal Map on a Shaded material*
 
-A Normal Map will affect anything that uses the Normal of a mesh (specifically the Pixel normal, as opposed to the Vertex normal, which is the normal defined by the mesh itself). This includes features like [Shading](/docs/shading/main.md), [Rim Lighting](/docs/shading/rim-lighting.md), [Reflections and Specular](/docs/shading/reflections-and-specular.md), [Matcaps](/docs/shading/matcap.md), and many other lighting-based effects.
+A Normal Map will affect anything that uses the Normal of a mesh (specifically the Pixel normal, as opposed to the Vertex normal, which is the normal defined by the mesh itself). This includes features like [Shading](/shading/main.md), [Rim Lighting](/shading/rim-lighting.md), [Reflections and Specular](/shading/reflections-and-specular.md), [Matcaps](/shading/matcap.md), and many other lighting-based effects.
 
 :::info Use OpenGL Format
 **Poiyomi Shaders, and across Unity as a whole, <u>requires OpenGL format</u> for Normal Maps.** Even though the game runs in DirectX, Unity always uses the OpenGL format.
@@ -98,4 +98,4 @@ In Transparent rendering modes like Fade, Transparent, TransClipping, etc., this
 
 <ReactVideo src='/vid/color-and-normals/main_Alpha-Cutoff_Fade.webm'/> 
 
-[^1]: [Special Unity Properties](/docs/general/locking.md#unity-special-properties)
+[^1]: [Special Unity Properties](/general/locking.md#unity-special-properties)

--- a/docs/color-and-normals/decals.md
+++ b/docs/color-and-normals/decals.md
@@ -149,7 +149,7 @@ Which blending operation to use from the Decal's Alpha channel.
 How much to apply the blended color to the base color.
 
 :::tip
-This slider can be animated to hide and show the decal. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+This slider can be animated to hide and show the decal. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ### Depth
@@ -170,7 +170,7 @@ Enable or Disable hue shifting of the Decal.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 #### Select or Shift
 
@@ -220,7 +220,7 @@ This feature enables a Video Texture to appear on the Decal. It will only work i
 <details>
 <summary><b>How to test Decal Video Textures</b></summary>
 
-1. Ensure you have the `AudioLinkAvatar` Prefab in your Scene, as described [here](/docs/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders).
+1. Ensure you have the `AudioLinkAvatar` Prefab in your Scene, as described [here](/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders).
 2. Inside the `AudioLinkAvatar` Prefab, expand it and select the object `AudioLinkYtdlpPlayer`. *This is the same place where you specify a YouTube video to use when testing Audio Link.*
 3. On the bottom line, **enable** the checkmark called `Enable Global Video Texture`.
 4. The Decal Video Texture can now be tested and debugged in the Unity Editor while in Play Mode.
@@ -309,18 +309,18 @@ Choice of where the Decal should appear on your Normals. You can choose it to ap
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply directly onto the Decal.
+Select which [Global Mask](/modifiers/global-masks.md) to apply directly onto the Decal.
 
 #### Apply To Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to send your Decal's effects onto the specified Global Mask.
+Select which [Global Mask](/modifiers/global-masks.md) to send your Decal's effects onto the specified Global Mask.
 
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Scale Band

--- a/docs/color-and-normals/details.md
+++ b/docs/color-and-normals/details.md
@@ -7,7 +7,7 @@ keywords: [details, tile, tiling, normals, base color, poiyomi, shader]
 
 The Details section provides options to apply additional textures (often tiled) to the base color and normals. When tiled, this feature can grant the user to bring out additional small details on the model without sacrificing quality.
 
-This section contains more customization features for 2nd Normals in comparison to [Normal Map 2](/docs/color-and-normals/normal-map-2.md).
+This section contains more customization features for 2nd Normals in comparison to [Normal Map 2](/color-and-normals/normal-map-2.md).
 
 ## Detail Mask
 
@@ -51,7 +51,7 @@ Multiplier for the detail texture's base brightness. Can be used to emphasize da
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Detail Texture onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Detail Texture onto.
 
 ## Detail Normal
 
@@ -71,4 +71,4 @@ Intensity multiplier for the detail normal map. Expand the Detail Normal texture
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Detail Normal onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Detail Normal onto.

--- a/docs/color-and-normals/normal-map-2.md
+++ b/docs/color-and-normals/normal-map-2.md
@@ -8,7 +8,7 @@ keywords: [normal map 2, normal, normals, map, 2nd normal, poiyomi, shader, unit
 The Normal Map 2 section adds an additional normal map to the surface, allowing additional detail to be added to a material without increasing the complexity of a mesh. This area is commonly referred to as "2nd Normal."
 
 :::info
-This section only contains basic features for a 2nd Normal, specifically for compatibility from other shaders. To use more advanced features, we recommend using [Detail Normals & Texture](/docs/color-and-normals/details.md) instead.
+This section only contains basic features for a 2nd Normal, specifically for compatibility from other shaders. To use more advanced features, we recommend using [Detail Normals & Texture](/color-and-normals/details.md) instead.
 :::
 
 ## Normal Map

--- a/docs/color-and-normals/rgba-color-masking.md
+++ b/docs/color-and-normals/rgba-color-masking.md
@@ -37,7 +37,7 @@ Use a Texture Mask to set the RGBA Mask. If enabled, it exposes the [Masks](#mas
 
 ### Vertex Colors
 
-Use the mesh's [Vertex Colors](/docs/vertex-options/vertex-colors.md) to set the RGBA Mask.
+Use the mesh's [Vertex Colors](/vertex-options/vertex-colors.md) to set the RGBA Mask.
 
 :::note Linear Vertex Colors Recommended
 When using Vertex Colors as the RGBA Mask, make sure the Color Attributes on the Mesh are in **Linear** Color so that the shader can accurately read them.

--- a/docs/download/download.md
+++ b/docs/download/download.md
@@ -139,7 +139,7 @@ The VCC version of Poiyomi Shaders will automatically replace any existing copy 
 
 The Pro version of the shader (also known as Poiyomi Pro) is a Paid Version of the shader, available as a subscription model for $10/month on Patreon. It contains extra special features that are [outlined below](#features-chart).
 
-Before using Poiyomi Pro, please ensure you agree to the [EULA](/docs/terms-of-service/terms-of-service.md#pro-version).
+Before using Poiyomi Pro, please ensure you agree to the [EULA](/terms-of-service/terms-of-service.md#pro-version).
 
 <div style={{marginBottom: '20px'}}>
 
@@ -181,7 +181,7 @@ Things work a little differently when using this version upon launching your Uni
 
 Do keep in mind that this script is intentionally designed to require an active subscription in order to receive future updates. So when updating Poiyomi Pro, you must go through the same process as detailed above.
 
-By using Poiyomi Pro, you agree to the EULA stated [here](/docs/terms-of-service/terms-of-service.md#pro-version).
+By using Poiyomi Pro, you agree to the EULA stated [here](/terms-of-service/terms-of-service.md#pro-version).
 
 ### Features Chart
 
@@ -190,44 +190,44 @@ To see the different features offered between the Free vs. Pro version, refer to
 | Role Access | Public | $2/month | $5/month | $10/month | $20/month | $50/month |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: |
 | **Toon/Pro Features** | | Nano | Micro | Mega | Giga | Tera |
-| [Color & Normals](/docs/color-and-normals/color-and-normals.md), [Color Adjust (Hue Shift)](/docs/color-and-normals/color-adjust.md), [Details](/docs/color-and-normals/details.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Alpha Options](/docs/color-and-normals/alpha-options.md), [Back Face](/docs/color-and-normals/back-face.md), [Normal Correct](/docs/color-and-normals/normal-correct.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Decals](/docs/color-and-normals/decals.md), [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Anisotropics](/docs/shading/anisotropics.md), [Matcaps](/docs/shading/matcap.md), [CubeMap](/docs/shading/cubemap.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Rim Lighting](/docs/shading/rim-lighting.md), [Depth Rim Lighting](/docs/shading/depth-rim-lighting.md), [Subsurface Scattering](/docs/shading/subsurface-scattering.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Reflections & Specular](/docs/shading/reflections-and-specular.md), [Clear Coat](/docs/shading/clear-coat.md), [Environmental Rim](/docs/shading/environmental-rim.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Stylized Reflections](/docs/shading/stylized-reflections.md), [Backlight](/docs/shading/backlight.md), [LTCGI](/docs/shading/ltcgi.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Outlines](/docs/outlines/outlines.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), [Proximity Color](/docs/special-fx/proximity-color.md), [Mirror/Camera Visibility](/docs/special-fx/mirror.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Depth Bulge](/docs/special-fx/depth-bulge.md), [Depth FX](/docs/special-fx/depth-fx.md), [Internal Parallax](/docs/special-fx/internal-parallax.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Emissions](/docs/special-fx/emission.md), [Glitter/Sparkle](/docs/special-fx/glitter.md), [Dissolve](/docs/special-fx/dissolve.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Flipbook](/docs/special-fx/flipbook.md), [Pathing](/docs/special-fx/pathing.md), [Stats Overlay](/docs/special-fx/stats-overlay.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Stats Overlay](/docs/special-fx/stats-overlay.md), [Video Effects](/docs/special-fx/video-effects.md), [Voronoi](/docs/special-fx/voronoi.md), [Truchet](/docs/special-fx/truchet.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Audio Link](/docs/audio-link/audio-link.md), [Global Themes](/docs/modifiers/global-themes.md), [Global Mask](/docs/modifiers/global-masks.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Color & Normals](/color-and-normals/color-and-normals.md), [Color Adjust (Hue Shift)](/color-and-normals/color-adjust.md), [Details](/color-and-normals/details.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Alpha Options](/color-and-normals/alpha-options.md), [Back Face](/color-and-normals/back-face.md), [Normal Correct](/color-and-normals/normal-correct.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Decals](/color-and-normals/decals.md), [RGBA Color Masking](/color-and-normals/rgba-color-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Anisotropics](/shading/anisotropics.md), [Matcaps](/shading/matcap.md), [CubeMap](/shading/cubemap.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Rim Lighting](/shading/rim-lighting.md), [Depth Rim Lighting](/shading/depth-rim-lighting.md), [Subsurface Scattering](/shading/subsurface-scattering.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Reflections & Specular](/shading/reflections-and-specular.md), [Clear Coat](/shading/clear-coat.md), [Environmental Rim](/shading/environmental-rim.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Stylized Reflections](/shading/stylized-reflections.md), [Backlight](/shading/backlight.md), [LTCGI](/shading/ltcgi.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Outlines](/outlines/outlines.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [UV Tile Discard](/special-fx/uv-tile-discard.md), [Proximity Color](/special-fx/proximity-color.md), [Mirror/Camera Visibility](/special-fx/mirror.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Depth Bulge](/special-fx/depth-bulge.md), [Depth FX](/special-fx/depth-fx.md), [Internal Parallax](/special-fx/internal-parallax.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Emissions](/special-fx/emission.md), [Glitter/Sparkle](/special-fx/glitter.md), [Dissolve](/special-fx/dissolve.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Flipbook](/special-fx/flipbook.md), [Pathing](/special-fx/pathing.md), [Stats Overlay](/special-fx/stats-overlay.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Stats Overlay](/special-fx/stats-overlay.md), [Video Effects](/special-fx/video-effects.md), [Voronoi](/special-fx/voronoi.md), [Truchet](/special-fx/truchet.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Audio Link](/audio-link/audio-link.md), [Global Themes](/modifiers/global-themes.md), [Global Mask](/modifiers/global-masks.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [VRC Light Volumes <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://github.com/REDSIM/VRCLightVolumes) Support | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [BlackLight Masking](/docs/modifiers/blacklight-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [BlackLight Masking](/modifiers/blacklight-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Stochastic Sampling, Distortion UV, Panosphere UV, Polar UV | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Parallax Heightmapping](/docs/modifiers/uvs/parallax.md), [Post Processing Animations](/docs/modifiers/post-processing/pp-animations.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Lil Fur](/docs/extended-features/lilfur.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Parallax Heightmapping](/modifiers/uvs/parallax.md), [Post Processing Animations](/modifiers/post-processing/pp-animations.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Lil Fur](/extended-features/lilfur.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Vertex Options |  |  |  |  |  |  |
-| [Basics & Fun](/docs/vertex-options/basics.md), [Glitching](/docs/vertex-options/glitching.md), [LookAt](/docs/vertex-options/look-at.md), [Vertex Colors](/docs/vertex-options/vertex-colors.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Shading Styles](/docs/shading/main.md) |  |  |  |  |  |  |
+| [Basics & Fun](/vertex-options/basics.md), [Glitching](/vertex-options/glitching.md), [LookAt](/vertex-options/look-at.md), [Vertex Colors](/vertex-options/vertex-colors.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Shading Styles](/shading/main.md) |  |  |  |  |  |  |
 | Texture Ramp, Multilayer Math, Wrapped, Skin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ShadeMap, Flat, Realistic, Cloth, SDF | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Rendering Presets](/docs/general/render-preset.md) |  |  |  |  |  |  |
+| [Rendering Presets](/general/render-preset.md) |  |  |  |  |  |  |
 | Opaque, Cutout, TransClipping, Fade, Transparent | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Additive, Soft Additive, Multiplicative, 2x Multiplicative | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Two Pass Transparency | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Grab Pass](/docs/extended-features/grabpass.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Grab Pass](/extended-features/grabpass.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Pro Features** | | | | | | |
-| [Screen Space Ambient Occlusion](/docs/shading/ssao.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Screen Space Ambient Occlusion](/shading/ssao.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Custom Modules | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Geometric Dissolve](/docs/extended-features/geometric-dissolve.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Fur and World Fur](/docs/extended-features/fur.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Shatterwave](/docs/extended-features/shatterwave.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Tessellated](/docs/extended-features/tessellated.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Geometric Dissolve](/extended-features/geometric-dissolve.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Fur and World Fur](/extended-features/fur.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Shatterwave](/extended-features/shatterwave.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Tessellated](/extended-features/tessellated.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Tessellated Geometric | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Particles](/docs/extended-features/particle.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Particles](/extended-features/particle.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Constellation | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Wireframe | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | NameTag | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |

--- a/docs/extended-features/fur.md
+++ b/docs/extended-features/fur.md
@@ -96,7 +96,7 @@ Enables options to change the Hue of the fur color using the Animator.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 

--- a/docs/extended-features/geometric-dissolve.md
+++ b/docs/extended-features/geometric-dissolve.md
@@ -318,7 +318,7 @@ Shows only the Wireframe.
 Allows an alternative way to use UV Tile Discard with the use of Geometric Dissolve's advanced effects instead.
 
 :::info Refer to UV Tile Documentation
-All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
+All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
 
 Each Slider will control the `Dissolve Alpha` for the described Row and Column.
 :::
@@ -333,7 +333,7 @@ Choice of which UV to use for the Tile Dissolve.
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `-1.0 - 1.0`
 
-This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
+This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
 
 |  | Column 0 | Column 1 | Column 2 | Column 3 |
 | :---: | :---: | :---: | :---: | :---: |

--- a/docs/extended-features/grabpass.md
+++ b/docs/extended-features/grabpass.md
@@ -134,7 +134,7 @@ Scaler for the blend amount. The Grab Pass color is blended with the base color 
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) should be used as the Blend Map.
+Select which [Global Mask](/modifiers/global-masks.md) should be used as the Blend Map.
 
 ### Source/Destination Blend
 
@@ -142,4 +142,4 @@ Select which [Global Mask](/docs/modifiers/global-masks.md) should be used as th
 
 Blend factor to use for the source and destination factors, respectively.
 
-For traditional transparent blending, `Source Blend` should be set to `SrcAlpha` and `Destination Blend` should be set to `OneMinusSrcAlpha`. Other factors can be used for other effects. Try some of the combinations listed in [Render Presets](/docs/general/render-preset.md#blending).
+For traditional transparent blending, `Source Blend` should be set to `SrcAlpha` and `Destination Blend` should be set to `OneMinusSrcAlpha`. Other factors can be used for other effects. Try some of the combinations listed in [Render Presets](/general/render-preset.md#blending).

--- a/docs/extended-features/lilfur.md
+++ b/docs/extended-features/lilfur.md
@@ -21,7 +21,7 @@ Please keep this in mind when using Lil Fur.
 
 This chooses the rendering mode to use for Lil Fur. Settings will be applied to the module's [Rendering](#rendering) properties.
 
-For reference on the meanings of these modes, see [Rendering Presets](/docs/general/render-preset.md).
+For reference on the meanings of these modes, see [Rendering Presets](/general/render-preset.md).
 
 ## Fur
 
@@ -133,7 +133,7 @@ Sets the Anti Light factor on the Fur's Rim Lighting.
 :::warning Heads Up
 These properties are automatically set based on the [Fur Mode](#fur-mode) set. If you intend to modify these properties below, please do so with care.
 
-Most, if not all properties that are listed here are the same descriptions as notated in [Rendering](/docs/rendering/rendering.md). However, these settings are completely independent of the material's overall Rendering settings.
+Most, if not all properties that are listed here are the same descriptions as notated in [Rendering](/rendering/rendering.md). However, these settings are completely independent of the material's overall Rendering settings.
 :::
 
 ### Cull
@@ -147,25 +147,25 @@ Sets what faces should be culled.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### DstBlend RGB
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### SrcBlend Alpha
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### DstBlend Alpha
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### BlendOp RGB
 
@@ -242,7 +242,7 @@ Sets the Alpha to affect the Mask of the Fur.
 ## Stencil
 
 :::warning Heads Up
-Most, if not all properties that are listed here are the same descriptions as notated in [Stencil](/docs/rendering/stencil.md). However, these settings are completely independent of the material's overall Stencil settings.
+Most, if not all properties that are listed here are the same descriptions as notated in [Stencil](/rendering/stencil.md). However, these settings are completely independent of the material's overall Stencil settings.
 :::
 
 ### Stencil Type

--- a/docs/extended-features/particle.md
+++ b/docs/extended-features/particle.md
@@ -17,7 +17,7 @@ To use Poiyomi Pro Particle, select the shader version `.poiyomi/Poiyomi Pro Par
 :::tip Works best with Cutout or Transparent Rendering
 Like many Particles, they each spawn with square-shaped planes that contains a texture. Most commonly, those textures have transparent backgrounds.
 
-When using a Texture or Sprite Sheet with a transparent background, change your [Rendering Preset](/docs/general/render-preset.md) to `Cutout` or a preferred transparent preset (if using Alpha transitions) for the best effect.
+When using a Texture or Sprite Sheet with a transparent background, change your [Rendering Preset](/general/render-preset.md) to `Cutout` or a preferred transparent preset (if using Alpha transitions) for the best effect.
 :::
 
 <ReactVideo src='/vid/extended-features/overkillparticles.webm'/>
@@ -83,7 +83,7 @@ Use a Vertex Color Channel from your mesh as the Spawn Mask.
 This should be the main texture you wish to use for the Particle's overall appearance.
 
 :::tip Use a texture with Transparency
-We recommend using a texture that has a transparent background. For best results, use Cutout or a Transparent [Rendering Preset](/docs/general/render-preset.md) on your Material for your Particles to appear correctly.
+We recommend using a texture that has a transparent background. For best results, use Cutout or a Transparent [Rendering Preset](/general/render-preset.md) on your Material for your Particles to appear correctly.
 :::
 
 ### Color
@@ -291,7 +291,7 @@ The bias of how each Frame is treated.
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Gradient Source

--- a/docs/extended-features/shatterwave.md
+++ b/docs/extended-features/shatterwave.md
@@ -5,7 +5,7 @@ description: Poiyomi ShatterWave is an advanced special effect that uses the mes
 keywords: [shatterwave, poiyomi, shader]
 ---
 
-ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. This effect is very similar to [Geometric Dissolve](/docs/extended-features/geometric-dissolve.md) with the exception of it being animated in an ocean wave-like effect instead.
+ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. This effect is very similar to [Geometric Dissolve](/extended-features/geometric-dissolve.md) with the exception of it being animated in an ocean wave-like effect instead.
 
 To use Poiyomi ShatterWave, select the shader version `.poiyomi/Poiyomi Pro ShatterWave`. This exposes the ShatterWave category with the following settings shown below.
 
@@ -52,7 +52,7 @@ Creates an Emissive effect on the ShatterWave's color.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Allows you to add the currently set ShatterWave setup to be applied to an existing [Global Mask](/docs/modifiers/global-masks.md) of your choice.
+Allows you to add the currently set ShatterWave setup to be applied to an existing [Global Mask](/modifiers/global-masks.md) of your choice.
 
 ## Show Under Wave
 
@@ -82,7 +82,7 @@ Creates an Emissive effect underneath the ShatterWave's mesh.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Allows you to add the currently set Under Wave setup to be applied to an existing [Global Mask](/docs/modifiers/global-masks.md) of your choice.
+Allows you to add the currently set Under Wave setup to be applied to an existing [Global Mask](/modifiers/global-masks.md) of your choice.
 
 ## Wave Speed X Y Z
 
@@ -117,7 +117,7 @@ Measures how dense the waves are in tiled coordinates.
 Enables Audio Link to manipulate the ShatterWave.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ## Emission Multiplier Band

--- a/docs/extended-features/two-pass.md
+++ b/docs/extended-features/two-pass.md
@@ -7,7 +7,7 @@ keywords: [two pass, 2nd pass, two, pass, poiyomi, shader]
 
 The Two Pass version does two rendering passes on the shader with the inside of the Mesh rendered first and the outside second (Cull Front > Cull Back). This special version should only be used when creating Meshes that need to have double the rendering pass, especially with Transparency.
 
-To use the Two Pass shader, select the shader version `.poiyomi/Poiyomi Toon Two Pass`. When this shader is selected, a `2nd Pass` category will be exposed on the UI below Color & Normals with the properties shown below. Additionally, three additional sections will be exposed under [Rendering](/docs/rendering/rendering.md) and will appear as `2nd Pass Rendering`, `2nd Pass Blending`, and `2nd Pass Stencil`.
+To use the Two Pass shader, select the shader version `.poiyomi/Poiyomi Toon Two Pass`. When this shader is selected, a `2nd Pass` category will be exposed on the UI below Color & Normals with the properties shown below. Additionally, three additional sections will be exposed under [Rendering](/rendering/rendering.md) and will appear as `2nd Pass Rendering`, `2nd Pass Blending`, and `2nd Pass Stencil`.
 
 :::warning Performance Warning
 Because the Two Pass shader renders everything twice, it can have a slight performance impact. Use it wisely!
@@ -19,7 +19,7 @@ Because the Two Pass shader renders everything twice, it can have a slight perfo
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**
 
-Sets the Rendering Preset for the 2nd Pass. Refer to the [Rendering Presets](/docs/general/render-preset.md) for more information on what they do.
+Sets the Rendering Preset for the 2nd Pass. Refer to the [Rendering Presets](/general/render-preset.md) for more information on what they do.
 
 ### First Pass Mask
 
@@ -43,7 +43,7 @@ If enabled, the Second Pass will override the Main Color of the Material.
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `0.0 - 1.0`
 
-Just like it was described in [Color & Normals](/docs/color-and-normals/color-and-normals.md#alpha-cutoff), the **Alpha Cutoff** value sets the alpha value for the 2nd Pass at which to [clip](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-clip) a pixel. If the alpha value of a pixel is below this value, the pixel is [discarded](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-discard).
+Just like it was described in [Color & Normals](/color-and-normals/color-and-normals.md#alpha-cutoff), the **Alpha Cutoff** value sets the alpha value for the 2nd Pass at which to [clip](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-clip) a pixel. If the alpha value of a pixel is below this value, the pixel is [discarded](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-discard).
 
 ### Invert Alpha Cutoff
 
@@ -55,7 +55,7 @@ This inverts the Alpha Cutoff.
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Just like it was described in [Alpha Options](/docs/color-and-normals/alpha-options.md#force-opaque), this option forces the 2nd Pass to have an alpha value of 1. Generally, this will result in any transparency on the 2nd Pass being disabled.
+Just like it was described in [Alpha Options](/color-and-normals/alpha-options.md#force-opaque), this option forces the 2nd Pass to have an alpha value of 1. Generally, this will result in any transparency on the 2nd Pass being disabled.
 
 ### Alpha Power
 

--- a/docs/general/alt-versions.md
+++ b/docs/general/alt-versions.md
@@ -31,7 +31,7 @@ We recommend only using this Shader if you are using the Worlds SDK.
 
 - `.poiyomi/Poiyomi Toon Two Pass`
 
-The Two Pass version renders the inside of the Mesh first, rather than the outside (Cull Front > Cull Back). See [Two Pass](/docs/extended-features/two-pass.md) for more info.
+The Two Pass version renders the inside of the Mesh first, rather than the outside (Cull Front > Cull Back). See [Two Pass](/extended-features/two-pass.md) for more info.
 
 Because the Two Pass shader renders everything twice, it can have a slight performance impact.
 
@@ -47,7 +47,7 @@ As Outline Early renders the Outline twice, it can have a slight performance imp
 
 - `.poiyomi/Poiyomi Toon Grab Pass`
 
-The Grab Pass Shader is used for specialized effects that require taking a screenshot every frame in order for it to render. See [Grab Pass](/docs/extended-features/grabpass.md) for more info.
+The Grab Pass Shader is used for specialized effects that require taking a screenshot every frame in order for it to render. See [Grab Pass](/extended-features/grabpass.md) for more info.
 
 Because this shader version uses a Grab Pass, it has the <u>strongest performance impact</u> as it has to take a screenshot every frame to render. If you wish to use this feature, use it judiciously!
 
@@ -55,13 +55,13 @@ Because this shader version uses a Grab Pass, it has the <u>strongest performanc
 
 - `.poiyomi/Poiyomi Pro Geometric Dissolve`
 
-Poiyomi Pro Geometric Dissolve is an advanced version in Poiyomi Pro that expands beyond the features of what a typical Dissolve can offer. It uses the 3D Mesh to manipulate the vertices, creating an advanced 3D Dissolve animation. See [Geometric Dissolve](/docs/extended-features/geometric-dissolve.md) for more info.
+Poiyomi Pro Geometric Dissolve is an advanced version in Poiyomi Pro that expands beyond the features of what a typical Dissolve can offer. It uses the 3D Mesh to manipulate the vertices, creating an advanced 3D Dissolve animation. See [Geometric Dissolve](/extended-features/geometric-dissolve.md) for more info.
 
 ## Fur
 
 - `.poiyomi/Poiyomi Pro Fur`
 
-Poiyomi Pro Fur is a system in Poiyomi Pro that uses a height-based technique to enable simulation of fabrics and hairs. It can look similar to how fur is simulated in animated films but with some differences. See [Fur](/docs/extended-features/fur.md) for more info.
+Poiyomi Pro Fur is a system in Poiyomi Pro that uses a height-based technique to enable simulation of fabrics and hairs. It can look similar to how fur is simulated in animated films but with some differences. See [Fur](/extended-features/fur.md) for more info.
 
 Fur simulation is a very expensive feature, as it must render every frame in order to simulate the effect. As such, this will cause a huge performance impact when used.
 
@@ -69,13 +69,13 @@ Fur simulation is a very expensive feature, as it must render every frame in ord
 
 - `.poiyomi/Poiyomi Pro ShatterWave`
 
-Poiyomi Pro ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. It functions similar to Geometric Dissolve, but does it in a wavy pattern instead. See [ShatterWave](/docs/extended-features/shatterwave.md) for more info.
+Poiyomi Pro ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. It functions similar to Geometric Dissolve, but does it in a wavy pattern instead. See [ShatterWave](/extended-features/shatterwave.md) for more info.
 
 ## Tessellated
 
 - `.poiyomi/Poiyomi Pro Tessellated`
 
-The Tessellated shader includes a shading process that subdivides triangles into a more realistic structure for certain realistic effects. See [Tessellated](/docs/extended-features/tessellated.md) for more info.
+The Tessellated shader includes a shading process that subdivides triangles into a more realistic structure for certain realistic effects. See [Tessellated](/extended-features/tessellated.md) for more info.
 
 Tessellated shaders are extremely expensive and will greatly hinder your computer's performance, even on the most powerful hardware out there. Please exercise caution if using it.
 
@@ -83,7 +83,7 @@ Tessellated shaders are extremely expensive and will greatly hinder your compute
 
 - `.poiyomi/Poiyomi Pro Particle`
 
-Poiyomi Pro Fur is a Geometric Particle shader that uses the 3D mesh to spawn each Particle from, similar to a Particle System in Unity. See [Particle](/docs/extended-features/particle.md) for more info.
+Poiyomi Pro Fur is a Geometric Particle shader that uses the 3D mesh to spawn each Particle from, similar to a Particle System in Unity. See [Particle](/extended-features/particle.md) for more info.
 
 Just like Geometric Dissolve, it can have a significant performance impact.
 
@@ -92,6 +92,6 @@ Just like Geometric Dissolve, it can have a significant performance impact.
 - `.poiyomi/Poiyomi Toon + Lil Fur`
 - `.poiyomi/Poiyomi Toon + Lil Fur Two Pass`
 
-Similar to Poiyomi Fur, but instead uses the same simulation technique on LilToon's Fur Shader. See [Lil Fur](/docs/extended-features/lilfur.md) for more details.
+Similar to Poiyomi Fur, but instead uses the same simulation technique on LilToon's Fur Shader. See [Lil Fur](/extended-features/lilfur.md) for more details.
 
 The Lil Fur shader uses a separate pass for the fur shading, meaning it does not stack with other Poiyomi features. However, this shader may have a performance impact.

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -15,7 +15,7 @@ This is a list of Frequently Asked Questions regarding Poiyomi Shaders. If you a
 
 ### What is the Poiyomi Shaders Terms of Service?
 
-A dedicated page is available which shows important information about the usage of the Shader. Please see [Terms of Service](/docs/terms-of-service/terms-of-service.md) for more details.
+A dedicated page is available which shows important information about the usage of the Shader. Please see [Terms of Service](/terms-of-service/terms-of-service.md) for more details.
 
 ### I'm trying to import a version that's in-between the versions the Unity Package specifies. How do I install them?
 
@@ -59,17 +59,17 @@ If this function fails to work and you get that message, ensure there are no scr
 
 ### How do I upgrade Poiyomi Shaders to a newer version?
 
-To upgrade the shader, refer to the instructions found in [Download & Install](/docs/download/download.md) for the Method you used when you first installed the Shader.
+To upgrade the shader, refer to the instructions found in [Download & Install](/download/download.md) for the Method you used when you first installed the Shader.
 
 Sometimes when updating your locked materials may get stuck in the locked state. This happens because the name of the shader changed. Avoid this by unlocking materials before updating. To Fix this, reselect the correct Poiyomi shader for the broken materials.
 
 :::warning
-If you are jumping from much older versions (7.3 or older) to the latest, [please refer to this documentation to learn how to account for these major changes](/docs/general/upgrade/upgrade.md).
+If you are jumping from much older versions (7.3 or older) to the latest, [please refer to this documentation to learn how to account for these major changes](/general/upgrade/upgrade.md).
 :::
 
 ### I'm trying to animate a property in the Material which kind of works, but it STOPS working when the Material gets Locked. What can I do?
 
-You need to mark properties that you are animating by `Right-Clicking` on them and selecting `Animated` or `Renamed`, which are specific tags that ensure the property remains accessible when the Shader is locked. For more information, see the Documentation page [Locking and Animation](/docs/general/locking.md#marking-properties-for-animation) for further reading.
+You need to mark properties that you are animating by `Right-Clicking` on them and selecting `Animated` or `Renamed`, which are specific tags that ensure the property remains accessible when the Shader is locked. For more information, see the Documentation page [Locking and Animation](/general/locking.md#marking-properties-for-animation) for further reading.
 
 Keep in mind that properties marked as `Renamed` will only work when the Material is Locked. **Make sure you Lock the Material prior to recording your animations!**
 
@@ -79,9 +79,9 @@ Keep in mind that properties marked as `Renamed` will only work when the Materia
 
 ### Where do AO Maps go in Poiyomi Shaders?
 
-Place AO (Ambient Occlusion) Maps in the [AO Maps](/docs/shading/light-data.md#ao-maps) Texture Slot, located in `Shading -> Light Data`.
+Place AO (Ambient Occlusion) Maps in the [AO Maps](/shading/light-data.md#ao-maps) Texture Slot, located in `Shading -> Light Data`.
 
-It is recommended to use a [Lighting Type](/docs/shading/main.md#lighting-type) that supports AO Maps. Only Realistic-based Lighting Types will allow AO maps to appear correctly.
+It is recommended to use a [Lighting Type](/shading/main.md#lighting-type) that supports AO Maps. Only Realistic-based Lighting Types will allow AO maps to appear correctly.
 
 ### Where does Height Maps go in Poiyomi Shaders?
 
@@ -89,7 +89,7 @@ Height maps are generally used to change the shape of the surface of a material.
 
 If you have a height map but not a normal map, you can convert it in Unity by setting the texture to a Normal map and selecting `Convert from Grayscale`.
 
-If you need the displacement, you can use it with [Parallax Heightmapping](/docs/modifiers/uvs/parallax.md), which creates a displacement-like effect. You can also use a shader that tessellates, which will add geometry to create the height detail. Please be aware that this is not an optimized method and may have a performance impact!
+If you need the displacement, you can use it with [Parallax Heightmapping](/modifiers/uvs/parallax.md), which creates a displacement-like effect. You can also use a shader that tessellates, which will add geometry to create the height detail. Please be aware that this is not an optimized method and may have a performance impact!
 
 ### What is the difference between Roughness vs. Smoothness Maps?
 
@@ -97,19 +97,19 @@ Roughness and Smoothness have the same information, just flipped!
 
 You can invert it in an image editor or use the invert checkboxes.
 
-**For v8+**, Roughness goes in [Reflections & Specular](/docs/shading/reflections-and-specular.md).
+**For v8+**, Roughness goes in [Reflections & Specular](/shading/reflections-and-specular.md).
 
-Open Packed Maps by clicking on the triangle and place the Roughness in the [G Smoothness Map](/docs/shading/reflections-and-specular.md#packed-maps) slot. It is important that you checkmark `Invert` so that it matches the Unity PBR Shading Pipeline. [Refer to the Documentation Page](/docs/shading/reflections-and-specular.md#packed-maps) for more information.
+Open Packed Maps by clicking on the triangle and place the Roughness in the [G Smoothness Map](/shading/reflections-and-specular.md#packed-maps) slot. It is important that you checkmark `Invert` so that it matches the Unity PBR Shading Pipeline. [Refer to the Documentation Page](/shading/reflections-and-specular.md#packed-maps) for more information.
 
 ### How do I test Audio Link in Poiyomi Shaders?
 
-We have dedicated instructions in our Audio Link feature Documentation on how to test Audio Link in Unity. [Please take a look at it (Click Here)](/docs/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders)
+We have dedicated instructions in our Audio Link feature Documentation on how to test Audio Link in Unity. [Please take a look at it (Click Here)](/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders)
 
 ### Why isn't Audio Link playing music in the Scene?
 
 The `AudioLinkAvatar` prefab in the scene uses the yt-dlp plugin from the VRChat installation files. However, YouTube has continuously made destructive changes to the audio/video format, which breaks it's functionality.
 
-Instead, you will need to manually specify a separate `yt-dlp.exe` to use instead to play audio. [Read the instructions carefully on our Docs (Click Here)](/docs/audio-link/audio-link.md#using-a-custom-ytdl-location)
+Instead, you will need to manually specify a separate `yt-dlp.exe` to use instead to play audio. [Read the instructions carefully on our Docs (Click Here)](/audio-link/audio-link.md#using-a-custom-ytdl-location)
 
 ### I am using a feature that is supposed to animate, but it doesn't show it's animating. Why is that?
 
@@ -147,18 +147,18 @@ Due to Unity Editor limitations, you cannot do this as it can cause problems at 
 
 While it is not possible to animate texture slots, Poiyomi Shaders has features that can make up for this. Try out using these modules:
 
-- [Decals](/docs/color-and-normals/decals.md), a decorative feature. You can animate the `Alpha` slider to control the visibility of the Texture using a Decal.
-- [Dissolve](/docs/special-fx/dissolve.md), a Special FX feature that can gradually introduce a different Texture through a visual transition.
-- [Geometric Dissove](/docs/extended-features/geometric-dissolve.md). Like Dissolve, but uses your Mesh's Geometry to transition to a different Texture.
-- [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), to animate offsets when needed.
+- [Decals](/color-and-normals/decals.md), a decorative feature. You can animate the `Alpha` slider to control the visibility of the Texture using a Decal.
+- [Dissolve](/special-fx/dissolve.md), a Special FX feature that can gradually introduce a different Texture through a visual transition.
+- [Geometric Dissove](/extended-features/geometric-dissolve.md). Like Dissolve, but uses your Mesh's Geometry to transition to a different Texture.
+- [UV Tile Discard](/special-fx/uv-tile-discard.md), to animate offsets when needed.
 
 ### What happened to "Basic Emission" in the shader?
 
 Basic Emission was removed in version 8.0 and newer because it was often used incorrectly.
 
-If you're wanting to make the model not too dark, it's generally better to use [Min Brightness](/docs/shading/light-data.md#min-brightness) located in Light Data for that purpose, as it won't over-brighten the avatar in various situations.
+If you're wanting to make the model not too dark, it's generally better to use [Min Brightness](/shading/light-data.md#min-brightness) located in Light Data for that purpose, as it won't over-brighten the avatar in various situations.
 
-If you REALLY need to add what used to be called "Basic Emission," you can use an [Emission](/docs/special-fx/emission.md) slot with `Use Base Colors` enabled and set a desired intensity.
+If you REALLY need to add what used to be called "Basic Emission," you can use an [Emission](/special-fx/emission.md) slot with `Use Base Colors` enabled and set a desired intensity.
 
 ### Why use OKLab for Hue Shift instead of HSV?
 
@@ -178,7 +178,7 @@ This can happen when you have a large number of materials using Poiyomi while un
 
 To circumvent this issue, you can lock materials when not in use, as that will generate unique shaders for each material.
 
-More information documented [here](/docs/general/textures-64-texture-slot-crash.md).
+More information documented [here](/general/textures-64-texture-slot-crash.md).
 
 ### Why does lighting change randomly while moving in a World?
 

--- a/docs/general/locking.md
+++ b/docs/general/locking.md
@@ -76,7 +76,7 @@ The unique suffix assigned for Properties marked as `RA` will depend on the name
 | **"Suit Jacket"** | Audio Link -> Anim Toggle | `_AudioLinkAnimToggle` | `_Suit_Jacket` | `_AudioLinkAnimToggle_Suit_Jacket` | 
 | **"Outfit Shirt"** | Color Adjust -> Hue Shift -> Hue Shift | `_MainHueShift` | `_Outfit_Shirt` | `_MainHueShift_Outfit_Shirt` |
 
-If you wish to enforce a specific custom renaming scheme for `RA` properties, enable [Allow custom renaming for locking](/docs/thryeditor/settings.md#allow-custom-renaming-for-locking) under Thry Editor settings. This exposes a dedicated field on the top of the material inspector, where you can type in a custom suffix for the material to use instead.
+If you wish to enforce a specific custom renaming scheme for `RA` properties, enable [Allow custom renaming for locking](/thryeditor/settings.md#allow-custom-renaming-for-locking) under Thry Editor settings. This exposes a dedicated field on the top of the material inspector, where you can type in a custom suffix for the material to use instead.
 
 ## Copying Properties for Animation
 
@@ -130,16 +130,16 @@ This behavior is not a bug, it's behavior defined by Unity, beyond the control o
 
 | Property Name | Can be Renamed? | Property |
 | :--- | :--- | :--- |
-| `_Color`                  | ✅ | [Main Color](/docs/color-and-normals/color-and-normals.md#color--alpha) |
-| `_MainTex_ST`             | ❌ | [Main Texture Tiling/Offset](/docs/color-and-normals/color-and-normals.md#texture) |
-| `_BumpMap_ST`             | ❌ | [Normal Map Tiling/Offset](/docs/color-and-normals/color-and-normals.md#normal-map) |
-| `_BumpScale`              | ✅ | [Normal Map Intensity](/docs/color-and-normals/color-and-normals.md#normal-map) |
-| `_Cutoff`                 | ✅ | [Alpha Cutoff](/docs/color-and-normals/color-and-normals.md#alpha-cutoff) |
-| `_DetailMask_ST`          | ❌ | [Detail Mask Tiling/Offset](/docs/color-and-normals/details.md#detail-mask) |
-| `_DetailNormalMap_ST`     | ❌ | [Detail Mask Tiling/Offset](/docs/color-and-normals/details.md#detail-normal) |
-| `_DetailNormalMapScale`   | ✅ | [Detail Mask Tiling/Offset](/docs/color-and-normals/details.md#normal-intensity) |
-| `_EmissionColor`          | ✅ | [Emission 0 Color](/docs/special-fx/emission.md#emission-color) |
-| `_EmissionMap_ST`         | ❌ | [Emission 0 Map Tiling/Offset](/docs/special-fx/emission.md#emission-map) |
+| `_Color`                  | ✅ | [Main Color](/color-and-normals/color-and-normals.md#color--alpha) |
+| `_MainTex_ST`             | ❌ | [Main Texture Tiling/Offset](/color-and-normals/color-and-normals.md#texture) |
+| `_BumpMap_ST`             | ❌ | [Normal Map Tiling/Offset](/color-and-normals/color-and-normals.md#normal-map) |
+| `_BumpScale`              | ✅ | [Normal Map Intensity](/color-and-normals/color-and-normals.md#normal-map) |
+| `_Cutoff`                 | ✅ | [Alpha Cutoff](/color-and-normals/color-and-normals.md#alpha-cutoff) |
+| `_DetailMask_ST`          | ❌ | [Detail Mask Tiling/Offset](/color-and-normals/details.md#detail-mask) |
+| `_DetailNormalMap_ST`     | ❌ | [Detail Mask Tiling/Offset](/color-and-normals/details.md#detail-normal) |
+| `_DetailNormalMapScale`   | ✅ | [Detail Mask Tiling/Offset](/color-and-normals/details.md#normal-intensity) |
+| `_EmissionColor`          | ✅ | [Emission 0 Color](/special-fx/emission.md#emission-color) |
+| `_EmissionMap_ST`         | ❌ | [Emission 0 Map Tiling/Offset](/special-fx/emission.md#emission-map) |
 
 ## Non-Animatable Properties
 
@@ -154,9 +154,9 @@ To adjust these properties at runtime, you'll need to create different materials
 These section checkboxes signal the shader to add and remove code. **Thus, they cannot be animated at runtime whatsoever**.
 
 If you want to toggle the effect of a section, use a property that controls the overall effect. For example,
-- To disable [Color Adjust](/docs/color-and-normals/color-adjust.md), you could animate the settings to their default values.
-- To disable a [Decal](/docs/color-and-normals/decals.md), animate its `Alpha` value to `0`. If the Decal has Emissions, also animate its `Emission Strength` value to `0`.
-- To disable [Audio Link](/docs/audio-link/audio-link.md), animate the `Anim Toggle` to be *un-checked*.
+- To disable [Color Adjust](/color-and-normals/color-adjust.md), you could animate the settings to their default values.
+- To disable a [Decal](/color-and-normals/decals.md), animate its `Alpha` value to `0`. If the Decal has Emissions, also animate its `Emission Strength` value to `0`.
+- To disable [Audio Link](/audio-link/audio-link.md), animate the `Anim Toggle` to be *un-checked*.
 
 For other sections, make sure to refer to the appropriate documentation pages on them so that you can know which properties you should animate as a toggle.
 
@@ -205,7 +205,7 @@ These options relate to low-level directives and settings that change how the gr
 
 The locking feature uses an optimization procedure developed by [Kaj](https://github.com/DarthShader/Kaj-Unity-Shaders). When the shader is locked in, a unique version is generated that removes unused code, defines fixed values for non-animated shader properties, and defined unused texture slots to be fixed values.
 
-This significantly improves performance, helps mitigate the [64 texture slot crash](/docs/general/textures-64-texture-slot-crash.md) sometimes seen when many complex materials with lots of modules enabled are present in a scene.
+This significantly improves performance, helps mitigate the [64 texture slot crash](/general/textures-64-texture-slot-crash.md) sometimes seen when many complex materials with lots of modules enabled are present in a scene.
 
 [^1]: For a more complete list, see the [List of some "Illegal Property Renames"](https://github.com/Thryrallo/ThryEditor/blob/master/Editor/ShaderOptimizer.cs#L227)
 

--- a/docs/general/render-preset.md
+++ b/docs/general/render-preset.md
@@ -7,7 +7,7 @@ keywords: [render, rendering, preset, opaque, cutout, transparent, transclipping
 
 At the top of the shader, there is a dropdown that may be labeled with something like `Opaque`, `Cutout`, `Transparent`, or something similar. It's located on the bottom-right from the Material Lock/Unlock button.
 
-When you click on this, the dropdown will show the options that are documented on this page. The option you select will automatically configure your [Rendering](/docs/rendering/rendering.md) settings to ensure they appear as intended.
+When you click on this, the dropdown will show the options that are documented on this page. The option you select will automatically configure your [Rendering](/rendering/rendering.md) settings to ensure they appear as intended.
 
 <a>
 <img src="/img/general/RenderingPresets-new.png" alt="Rendering Presets Dropdown Menu" width="700px"/>
@@ -33,8 +33,8 @@ Similar to Opaque, but allows a yes/no for whether a pixel should be rendered. T
 
 By default, cutout is binary: it either renders or it doesn't. You can use certain options to improve partially transparent areas and edges:
 
-- [Dithering](/docs/color-and-normals/alpha-options.md#dithering) uses a technique that introduces noise in order to provide a perceptually smoother transition between two sharp differences in alpha.
-- [Alpha to Coverage](/docs/color-and-normals/alpha-options.md#alpha-to-coverage) uses partial transparency values to provide variable transparency levels when the viewer is using Multi-Sampled Anti-Aliasing (MSAA). The number of transparency levels is equal to the MSAA level (x2, x4, x8, etc). VRChat allows users to select the number of MSAA levels they want to use through the in-game Graphics Settings, so it's best to make your material still look good even with no MSAA.
+- [Dithering](/color-and-normals/alpha-options.md#dithering) uses a technique that introduces noise in order to provide a perceptually smoother transition between two sharp differences in alpha.
+- [Alpha to Coverage](/color-and-normals/alpha-options.md#alpha-to-coverage) uses partial transparency values to provide variable transparency levels when the viewer is using Multi-Sampled Anti-Aliasing (MSAA). The number of transparency levels is equal to the MSAA level (x2, x4, x8, etc). VRChat allows users to select the number of MSAA levels they want to use through the in-game Graphics Settings, so it's best to make your material still look good even with no MSAA.
 
 :::tip
 You can enable MSAA in your Unity project by going to `Edit > Project Settings > Quality` and find the **Anti Aliasing** options. Use a starting level of `MSAA x4` and feel free to adjust to see how they appear with different MSAA levels.
@@ -115,7 +115,7 @@ The multiplicative preset will always either keep or darken the background color
 
 ### Options
 
-Render Presets Set a bunch of options for how a material should render. They are all set to the default values, but if you know what you're doing, you can adjust them in the [Rendering Settings](/docs/rendering/rendering.md) section.
+Render Presets Set a bunch of options for how a material should render. They are all set to the default values, but if you know what you're doing, you can adjust them in the [Rendering Settings](/rendering/rendering.md) section.
 
 The options that are set by default by rendering presets are:
 

--- a/docs/general/substance-painter.md
+++ b/docs/general/substance-painter.md
@@ -39,12 +39,12 @@ If you know how to create Export Templates in Substance Painter, refer to the gu
 
 Textures have specific naming calls when used: `t_$textureSet_Yourtexture(.$udim)`. `t` indicates it's a texture (and groups textures together when sorted), `$textureSet` which the name of the Material set set being used, and `$udim` which refers to the UDIM Tile of the texture (if your Substance Project is using UDIM).
 
-- `t_$textureSet_BaseColor(.$udim)`: Place in the [`Main Texture`](/docs/color-and-normals/color-and-normals.md#texture) slot in [Color & Normals](/docs/color-and-normals/color-and-normals.md).
-- `t_$textureSet_NormalMap(.$udim)`: Place in the [`Normal Map`](/docs/color-and-normals/color-and-normals.md#normal-map) texture slot in [Color & Normals](/docs/color-and-normals/color-and-normals.md). Make sure to mark it as a normal map in the texture import settings.
-- `t_$textureSet_AmbientOcclusion(.$udim)`: Place in the [`AO`](docs/shading/light-data.md#ao-maps) texture slot in [Light Data](/docs/shading/light-data.md). Make sure to **uncheck sRGB** in the texture import settings.
+- `t_$textureSet_BaseColor(.$udim)`: Place in the [`Main Texture`](/color-and-normals/color-and-normals.md#texture) slot in [Color & Normals](/color-and-normals/color-and-normals.md).
+- `t_$textureSet_NormalMap(.$udim)`: Place in the [`Normal Map`](/color-and-normals/color-and-normals.md#normal-map) texture slot in [Color & Normals](/color-and-normals/color-and-normals.md). Make sure to mark it as a normal map in the texture import settings.
+- `t_$textureSet_AmbientOcclusion(.$udim)`: Place in the [`AO`](/shading/light-data.md#ao-maps) texture slot in [Light Data](/shading/light-data.md). Make sure to **uncheck sRGB** in the texture import settings.
   - Three AO maps are encoded in the texture. This includes `Input AO`, `Mixed AO`, and `User3` for flexibility. `User3` is used for Customized AO mapping. Poiyomi Shaders supports exposing these maps through the sliders in their AO Slots.
-- `t_$textureSet_MetallicSmoothnessMaps(.$udim)`: Place in the [`Packed Maps`](/docs/shading/reflections-and-specular.md#packed-maps) texture slot in [Reflections & Specular](/docs/shading/reflections-and-specular.md). Make sure to **uncheck sRGB** in the texture import settings, and that all of your sliders are set to 1.0, which uses the map's value. Note that this uses `User0` and `User1` channels in Substance Painter for the Reflection and Specular masks respectively, which can be hand-authored to control the amount of reflection and specular.
-- `t_$textureSet_EmissionMap(.$udim)`: Place in the [`Emission Map`](/docs/special-fx/emission.md#emission-map) texture slot in [`Emission`](/docs/special-fx/emission.md).
+- `t_$textureSet_MetallicSmoothnessMaps(.$udim)`: Place in the [`Packed Maps`](/shading/reflections-and-specular.md#packed-maps) texture slot in [Reflections & Specular](/shading/reflections-and-specular.md). Make sure to **uncheck sRGB** in the texture import settings, and that all of your sliders are set to 1.0, which uses the map's value. Note that this uses `User0` and `User1` channels in Substance Painter for the Reflection and Specular masks respectively, which can be hand-authored to control the amount of reflection and specular.
+- `t_$textureSet_EmissionMap(.$udim)`: Place in the [`Emission Map`](/special-fx/emission.md#emission-map) texture slot in [`Emission`](/special-fx/emission.md).
 
 <a target="_blank" href="/img/general/substance_texturelocations.png">
 <img src="/img/general/substance_texturelocations.png" alt="v10 Export Texture Locations"/>
@@ -54,11 +54,11 @@ Textures have specific naming calls when used: `t_$textureSet_Yourtexture(.$udim
 
 ### Usage Notes
 
-PBR textures look best when paired with realistic lighting. To take best advantage of this, good [Shading](docs/shading/main.md) settings are recommended. Some good starting points include:
+PBR textures look best when paired with realistic lighting. To take best advantage of this, good [Shading](/shading/main.md) settings are recommended. Some good starting points include:
 
-- [Realistic](/docs/shading/main.md#realistic) shading
-- [Multilayer Math](/docs/shading/main.md#multilayer-math) shading, using only the first layer with a Border between `0.4` and `0.7` and a Blur of `0.4-0.6`
-- [Wrapped](/docs/shading/main.md#wrapped) shading with a wrap of around `1.0` and a normalization of around `0.5`
+- [Realistic](/shading/main.md#realistic) shading
+- [Multilayer Math](/shading/main.md#multilayer-math) shading, using only the first layer with a Border between `0.4` and `0.7` and a Blur of `0.4-0.6`
+- [Wrapped](/shading/main.md#wrapped) shading with a wrap of around `1.0` and a normalization of around `0.5`
 
 Matcaps are not recommended, as they don't respond to the lighting environment the way metallics and specular do.
 
@@ -69,12 +69,12 @@ PBR shading relies on the world lighting being well-defined and correct. In worl
 When using the `ExtraMaps` preset, additional textures are exported:
 
 - All textures from the [v10 preset](#textures).
-- `t_$textureSet_GlobalMask(.$udim)`: Place in one of the Global Mask texture slots in [`Global Mask`](/docs/modifiers/global-masks.md). Make sure to **uncheck sRGB** in the texture import settings. Note that this uses the custom **User channels** in Substance for your Masks. This Template is programmed to use `User10` for the `R` channel, `User11` for the `G` channel, `User12` for the `B` channel, and `User13` for the `A` channel.
+- `t_$textureSet_GlobalMask(.$udim)`: Place in one of the Global Mask texture slots in [`Global Mask`](/modifiers/global-masks.md). Make sure to **uncheck sRGB** in the texture import settings. Note that this uses the custom **User channels** in Substance for your Masks. This Template is programmed to use `User10` for the `R` channel, `User11` for the `G` channel, `User12` for the `B` channel, and `User13` for the `A` channel.
 - `t_$textureSet_ToonStandardSpecular(.$udim)`: Slightly different version of the Metallic Smoothness Map made specifically for setups requiring minimal VRAM, such as VRChat's Toon Standard.
   - The channels are intentionally mapped to reduce VRAM, which is different than Standard PBR mapping. Use the Channel Mapping in Toon Standard to line them up.
   - Use `(R)` for Metallic, `(G)` for Glossiness, and `(B)` for AO.
-- `t_$textureSet_SubsurfaceScattering(.$udim)`: Exports the `Scattering color` and `Scattering` channels into this map. Use this in Poiyomi's [Subsurface Scattering](/docs/shading/subsurface-scattering.md) feature.
-- `t_$textureSet_OutlineSizeMask(.$udim)`: Exports the `User2` channel. Use this for the Outline Size Mask, if using the [Outlines](/docs/outlines/outlines.md) feature.
+- `t_$textureSet_SubsurfaceScattering(.$udim)`: Exports the `Scattering color` and `Scattering` channels into this map. Use this in Poiyomi's [Subsurface Scattering](/shading/subsurface-scattering.md) feature.
+- `t_$textureSet_OutlineSizeMask(.$udim)`: Exports the `User2` channel. Use this for the Outline Size Mask, if using the [Outlines](/outlines/outlines.md) feature.
 - `t_$textureSet_AlphaMap(.$udim)`: Separate Alpha/Opacity map for the base texture. Can be used to optimize the base texture, or for other Alpha modifiers in the shader.
     - *You should not use Alpha Map unless it's absolutely necessary. This is because the Alpha is already encoded into the Main Texture when using the `Opacity` channel in Substance Painter.*
-- `t_$textureSet_Height(.$udim)`: Height map. Currently best used as a height texture in [Parallax Heightmapping](/docs/modifiers/uvs/parallax.md). Can also be used directly as a vertex offset, though this usually does not have the same effect.
+- `t_$textureSet_Height(.$udim)`: Height map. Currently best used as a height texture in [Parallax Heightmapping](/modifiers/uvs/parallax.md). Can also be used directly as a vertex offset, though this usually does not have the same effect.

--- a/docs/general/textures-and-colors.md
+++ b/docs/general/textures-and-colors.md
@@ -127,7 +127,7 @@ If you are an Avatar Creator, consider leaving this OFF in your Packages.
 
 This setting determines the maximum resolution of the texture after Unity compresses it. Texture resolution is the biggest driver of VRAM (Texture Memory) consumption, and it's important to keep your textures as low resolution as they can be while maintaining acceptable visual quality.
 
-4096px and 8192px square textures, in particular, **use large amounts of VRAM**. Where possible, make your textures smaller, and use features like [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md), alternate UV maps, [Decals](/docs/color-and-normals/decals.md), etc., to reduce the need for large, high resolution textures. Using those features can both help improve performance and cut down on VRAM consumption. Your friends will thank you.
+4096px and 8192px square textures, in particular, **use large amounts of VRAM**. Where possible, make your textures smaller, and use features like [RGBA Color Masking](/color-and-normals/rgba-color-masking.md), alternate UV maps, [Decals](/color-and-normals/decals.md), etc., to reduce the need for large, high resolution textures. Using those features can both help improve performance and cut down on VRAM consumption. Your friends will thank you.
 
 :::info VRChat Avatar Size Limits
 Make sure to keep the Max Size of your textures <u>as low as you can</u>, as it will greatly contribute to the final **Download Size** and **Uncompressed Size** of your Avatar. Failure to take this into account may prevent VRChat from even loading your Avatar at all, as it is subject to server-side scanning!
@@ -177,7 +177,7 @@ This option has a caveat. For most textures, the wrap mode defined for the *Main
 
 Most colors in the shader are standard RGBA colors. This means they are stored as four floating point values, with each value ranging from 0 to 1.
 
-Most color pickers have the option to draw from a [Global Theme](/docs/modifiers/global-themes.md), or from a world's Audio Link theme colors. This can be used to create an easy-to-change color palette for your avatar.
+Most color pickers have the option to draw from a [Global Theme](/modifiers/global-themes.md), or from a world's Audio Link theme colors. This can be used to create an easy-to-change color palette for your avatar.
 
 ### HDR Colors
 
@@ -187,13 +187,13 @@ In the Unity Standard Shader, the HDR Color `Intensity` slider serves as the Emi
 
 ### Alpha
 
-The Alpha channel is used to store opacity. It is a floating point value from 0 to 1. Generally, this is used to determine how much an effect or a part of an effect. For example, in [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md), the Alpha channel is used to determine how much of a channel's texture should be used.
+The Alpha channel is used to store opacity. It is a floating point value from 0 to 1. Generally, this is used to determine how much an effect or a part of an effect. For example, in [RGBA Color Masking](/color-and-normals/rgba-color-masking.md), the Alpha channel is used to determine how much of a channel's texture should be used.
 
 One notable exception is the base color, where the Alpha channel is used to determine the amount of opacity for the material.
 
 ### Vertex Colors
 
-[Vertex Colors](/docs/vertex-options/vertex-colors.md) are colors stored on each vertex of a mesh. They can be used to color the mesh, or to store data about the mesh, like each vertex's position, or smoothed vertex normals, both of which can be baked into the mesh using the `Poi -> Vertex Color Baker` tool.
+[Vertex Colors](/vertex-options/vertex-colors.md) are colors stored on each vertex of a mesh. They can be used to color the mesh, or to store data about the mesh, like each vertex's position, or smoothed vertex normals, both of which can be baked into the mesh using the `Poi -> Vertex Color Baker` tool.
 
 ### Color Blending/Tinting
 

--- a/docs/general/translation.md
+++ b/docs/general/translation.md
@@ -11,10 +11,10 @@ In Poiyomi Shaders, there are some properties that will completely differ from U
 
 When switching from the Standard shader to Poiyomi, most if not all properties will be carried over with a few exceptions. Please read below to see what will NOT be carried over:
 
-- **Metallic Smoothness**: Properties and Textures such as `_Metallic`, `_Glossiness`, and `MetalGlossMap`, will not be carried over as we use a different workflow as defined by Mochie. When switching over, you must adjust the workflow for [Reflections & Specular](/docs/shading/reflections-and-specular.md) in Poiyomi Shaders. See the documentation page linked in this paragraph to learn more.
-- **Occlusion**: This Texture Slot will not be carried over. However, you should be able to use it under the [AO Maps](/docs/shading/light-data.md) slot in Light Data without a problem. Do keep in mind that AO Maps will only work best with Realistic-based shading.
-- **Detail Maps**: This texture slot will not be carried over as we use a far more advanced setup in both [Details](/docs/color-and-normals/details.md) and [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md).
-- **Detail Albedo x2**: This texture slot will not be carried over as we use a more advanced approach in [Details](/docs/color-and-normals/details.md) feature.
+- **Metallic Smoothness**: Properties and Textures such as `_Metallic`, `_Glossiness`, and `MetalGlossMap`, will not be carried over as we use a different workflow as defined by Mochie. When switching over, you must adjust the workflow for [Reflections & Specular](/shading/reflections-and-specular.md) in Poiyomi Shaders. See the documentation page linked in this paragraph to learn more.
+- **Occlusion**: This Texture Slot will not be carried over. However, you should be able to use it under the [AO Maps](/shading/light-data.md) slot in Light Data without a problem. Do keep in mind that AO Maps will only work best with Realistic-based shading.
+- **Detail Maps**: This texture slot will not be carried over as we use a far more advanced setup in both [Details](/color-and-normals/details.md) and [RGBA Color Masking](/color-and-normals/rgba-color-masking.md).
+- **Detail Albedo x2**: This texture slot will not be carried over as we use a more advanced approach in [Details](/color-and-normals/details.md) feature.
 
 ## LilToon
 

--- a/docs/general/upgrade/v7-upgrade.md
+++ b/docs/general/upgrade/v7-upgrade.md
@@ -13,7 +13,7 @@ This page covers a few of the major differences between the two versions that sh
 
 ### Light Data
 
-**Ambient Occlusion** and **Direct Shadows** have been moved from a shading mode subsection to the [Light Data](/docs/shading/light-data.md) section. 
+**Ambient Occlusion** and **Direct Shadows** have been moved from a shading mode subsection to the [Light Data](/shading/light-data.md) section. 
 
 Various other settings have been moved to the Light Data section, including:
 
@@ -38,19 +38,19 @@ The "Toon" mode, with subsections for Toon Ramp, Math Gradient, and Shade Map, h
 
 #### Math Gradient -> Multilayer Math
 
-The Math Gradient mode has been reworked into a new mode called [Multilayer Math](/docs/shading/main.md#multilayer-math).
+The Math Gradient mode has been reworked into a new mode called [Multilayer Math](/shading/main.md#multilayer-math).
 
 The first shading layer is equivalent to the Math Gradient mode, with "Gradient Start" and "Gradient End" having been replaced by a shadow center point and a blur. Changing the center point is equivalent to changing the average of the "Gradient Start" and "Gradient End" settings, and changing the blur is equivalent to moving the "Gradient Start" and "Gradient End" settings closer or farther apart.
 
 ### Metallics/Metallics and Specular -> Reflections and Specular
 
-The "Metallics/Specular" and "Metallics (Deprecated)" sections have been removed, and PBR Reflections and Specular highlights have been re-worked significantly into the new [Reflections & Specular](/docs/shading/reflections-and-specular.md) module. A new inline packer has been introduced as well, which allow easy merging of Metallic and Smoothness Maps.
+The "Metallics/Specular" and "Metallics (Deprecated)" sections have been removed, and PBR Reflections and Specular highlights have been re-worked significantly into the new [Reflections & Specular](/shading/reflections-and-specular.md) module. A new inline packer has been introduced as well, which allow easy merging of Metallic and Smoothness Maps.
 
-By opening up the [Packed Maps](/docs/shading/reflections-and-specular.md#packed-maps) texture slot, you can insert individual maps into each channel. You can directly use metallic and smoothness/roughness maps, or you can use the inline packer to re-map your v7 maps to the new packed map. Put your v7 map texture in both the Metallic map and Smoothness map slots, and select `R` and `A` respectively to pull from the old metallic and smoothness channels. If you used the Reflectivity map, you can also put the v7 texture in the Reflection Mask slot and select `G`, but this may not have the intended effect due to the more accurate PBR implementation.
+By opening up the [Packed Maps](/shading/reflections-and-specular.md#packed-maps) texture slot, you can insert individual maps into each channel. You can directly use metallic and smoothness/roughness maps, or you can use the inline packer to re-map your v7 maps to the new packed map. Put your v7 map texture in both the Metallic map and Smoothness map slots, and select `R` and `A` respectively to pull from the old metallic and smoothness channels. If you used the Reflectivity map, you can also put the v7 texture in the Reflection Mask slot and select `G`, but this may not have the intended effect due to the more accurate PBR implementation.
 
 ### Specular Highlights 1/2 -> Stylized Specular/Anisotropics
 
-The custom specular highlights mode has been reworked into a new feature called [Stylized Reflections](/docs/shading/stylized-reflections.md), and Anisotropic reflections have been reworked into a new feature called [Anisotropics](/docs/shading/anisotropics.md).
+The custom specular highlights mode has been reworked into a new feature called [Stylized Reflections](/shading/stylized-reflections.md), and Anisotropic reflections have been reworked into a new feature called [Anisotropics](/shading/anisotropics.md).
 
 ## Color & Normals
 
@@ -58,13 +58,13 @@ The custom specular highlights mode has been reworked into a new feature called 
 
 Basic Emission has been removed as it was often used incorrectly.
 
-If you have a material that should always have a minimum brightness, use the [Min Brightness](/docs/shading/light-data.md#min-brightness) setting in the Light Data section.
+If you have a material that should always have a minimum brightness, use the [Min Brightness](/shading/light-data.md#min-brightness) setting in the Light Data section.
 
-If you need a material to have a uniform emission, use an Emission slot with [Use Base Colors](/docs/special-fx/emission.md#use-base-colors) enabled, and a white color. This will make the `Emission Strength` setting equivalent to the old "Basic Emission" setting.
+If you need a material to have a uniform emission, use an Emission slot with [Use Base Colors](/special-fx/emission.md#use-base-colors) enabled, and a white color. This will make the `Emission Strength` setting equivalent to the old "Basic Emission" setting.
 
 ### Alpha Options
 
-The Alpha options has been reworked, with Distance Alpha (Distance Fade), Fresnel Alpha, and Angular Alpha being moved to [Alpha Options](/docs/color-and-normals/alpha-options.md).
+The Alpha options has been reworked, with Distance Alpha (Distance Fade), Fresnel Alpha, and Angular Alpha being moved to [Alpha Options](/color-and-normals/alpha-options.md).
 
 ## Outlines
 
@@ -76,13 +76,13 @@ However, in V8.x versions, Outlines were moved to their own versions such as `.p
 
 ### Emission
 
-"Glow In The Dark" was renamed to [Light Based](/docs/special-fx/emission.md#light-based) in order to better describe the effect. It can still be used in the same way.
+"Glow In The Dark" was renamed to [Light Based](/special-fx/emission.md#light-based) in order to better describe the effect. It can still be used in the same way.
 
 "Multiply Emission Strength" was removed from emission audio link, as it conflicted with (and was less useful than) the X/Y min/max additive values. To recreate its effect, set the "Min" value of Emission Add to the negative value of your base emission strength, and the "Max" value of Emission Add to zero. In Worlds with AudioLink, this will result in no emission when there's no volume in the selected channel, and the base emission value when there is max volume in that channel.
 
 ### Dissolve
 
-"Dissolve Noise" was renamed to [Dissolve Gradient](/docs/special-fx/dissolve.md#dissolve-gradient), and "Dissolve Detail Noise" was renamed to [Dissolve Noise](/docs/special-fx/dissolve.md#dissolve-noise). This better reflects their functionality
+"Dissolve Noise" was renamed to [Dissolve Gradient](/special-fx/dissolve.md#dissolve-gradient), and "Dissolve Detail Noise" was renamed to [Dissolve Noise](/special-fx/dissolve.md#dissolve-noise). This better reflects their functionality
 
 If you only have one dissolve map, it should be put in the `Dissolve Gradient` slot.
 
@@ -100,4 +100,4 @@ To configure the behavior of Panosphere UVs, see the `Panosphere` section locate
 
 ### Parallax/Parallax Heightmapping
 
-Parallax/Parallax Heightmapping have been reworked to use the new UV option system, in [Parallax Heighmapping](/docs/modifiers/uvs/parallax.md). Similar to the Panosphere option, the parallax-modified UV can be applied to almost any texture in the shader, by modifying one of the base UV slots (0, 1, 2, 3).
+Parallax/Parallax Heightmapping have been reworked to use the new UV option system, in [Parallax Heighmapping](/modifiers/uvs/parallax.md). Similar to the Panosphere option, the parallax-modified UV can be applied to almost any texture in the shader, by modifying one of the base UV slots (0, 1, 2, 3).

--- a/docs/modifiers/blacklight-masking.md
+++ b/docs/modifiers/blacklight-masking.md
@@ -50,7 +50,7 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **One** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **One** effects onto.
 
 ## Two
 
@@ -75,7 +75,7 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **Two** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **Two** effects onto.
 
 ## Three
 
@@ -100,7 +100,7 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **Three** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **Three** effects onto.
 
 ## Four
 
@@ -125,4 +125,4 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **Four** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **Four** effects onto.

--- a/docs/modifiers/global-masks.md
+++ b/docs/modifiers/global-masks.md
@@ -27,7 +27,7 @@ Each Global Mask uses the `Red (R)`, `Green (G)`, `Blue (B)`, and `Alpha (A)` ch
 
 Since you have a total of 4 Global Masking slots, each providing 4 Color Channels, you can have up to 16 Color Channels to use for your Masks.
 
-*Below is a video introduction to Global Masking, courtesy of community member Teeh. This also briefly covers it's sister feature [Global Themes](/docs/modifiers/global-themes.md) as well.*
+*Below is a video introduction to Global Masking, courtesy of community member Teeh. This also briefly covers it's sister feature [Global Themes](/modifiers/global-themes.md) as well.*
 
 <div class="videobox">
 <iframe class="iframe-element" src="https://www.youtube-nocookie.com/embed/ng780niVSzA?si=TO5iXVR7NWWw4xNw" title="YouTube Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
@@ -51,7 +51,7 @@ Once done, see how to use them in [Usage in the Shader](#usage-in-the-shader).
 
 ### Method 2: Provide your own Texture
 
-Another way of creating Global Masks is by the use of software, such as Substance 3D Painter, to pack your `User` channels into an `R + G + B + A` Texture way in advance. To do this, you would have to add the `User` channels and paint on those channels you specify. We offer an example Export Template that shows the usage of this, which you can download from [here](/docs/general/substance-painter.md).
+Another way of creating Global Masks is by the use of software, such as Substance 3D Painter, to pack your `User` channels into an `R + G + B + A` Texture way in advance. To do this, you would have to add the `User` channels and paint on those channels you specify. We offer an example Export Template that shows the usage of this, which you can download from [here](/general/substance-painter.md).
 
 After exporting your `t_$textureSet_GlobalMask.png` file, slot it directly into one of the Global Mask slots. See [Usage in the Shader](#usage-in-the-shader) below to see how to use them.
 
@@ -109,7 +109,7 @@ Texture Slot defining the forth Global Mask. This will represent Global Masks `4
 
 ## Vertex Colors
 
-This section allows you to use [Vertex Colors](/docs/vertex-options/vertex-colors.md) on your Mesh as a Global Mask.
+This section allows you to use [Vertex Colors](/vertex-options/vertex-colors.md) on your Mesh as a Global Mask.
 
 ### Linear Colors
 

--- a/docs/modifiers/global-themes.md
+++ b/docs/modifiers/global-themes.md
@@ -43,7 +43,7 @@ Color to use for Theme Color.
 
 How much to shift the Theme Color around the Hue Circle. This value is circular, and will have the same result at 0 and 1.
 
-This functions in the same fashion as Color Adjust's [Hue Shift](/docs/color-and-normals/color-adjust.md#hue-shift-1) slider.
+This functions in the same fashion as Color Adjust's [Hue Shift](/color-and-normals/color-adjust.md#hue-shift-1) slider.
 
 ### Hue Adjust Speed
 

--- a/docs/modifiers/uvs/distortion-uv.md
+++ b/docs/modifiers/uvs/distortion-uv.md
@@ -56,7 +56,7 @@ Sets the strength of the Distortion from Texture 2.
 ### Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 #### Strength 1 Band

--- a/docs/modular-shader-system/modular-shader-system.md
+++ b/docs/modular-shader-system/modular-shader-system.md
@@ -10,7 +10,7 @@ Poiyomi Shaders is put together using the Modular Shader System, which allows fo
 :::info Attention Shader Developers
 For security reasons, the Modular Shader components and modules referenced here are only exposed for end-user access in the Poiyomi Pro shader package, as it also exposes Pro-only modules.
 
-To learn more on how to obtain the Poiyomi Pro version, see [Download & Install: Poiyomi Pro](/docs/download/download.md#poiyomi-pro).
+To learn more on how to obtain the Poiyomi Pro version, see [Download & Install: Poiyomi Pro](/download/download.md#poiyomi-pro).
 :::
 
 ## Overview

--- a/docs/outlines/outlines.md
+++ b/docs/outlines/outlines.md
@@ -135,7 +135,7 @@ Determines if you want the Outlines to blend in a way that is similar to Unity-C
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Enables the ability to modify the Outline Color in a similar fashion to [Color Adjust](/docs/color-and-normals/color-adjust.md). This is applied directly after the main [Outline Color](#color), and will not affect other sections that modify the base Outline Color.
+Enables the ability to modify the Outline Color in a similar fashion to [Color Adjust](/color-and-normals/color-adjust.md). This is applied directly after the main [Outline Color](#color), and will not affect other sections that modify the base Outline Color.
 
 :::info This area was recently updated!
 All of these values can be individually animated as of the latest version.
@@ -300,7 +300,7 @@ If enabled, will invert the value from the [Outline Mask Channel](#outline-mask-
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`R`/`G`/`B`/`A`
 
-Which [Vertex Color](/docs/vertex-options/vertex-colors.md) channel to use to control the Outline Z Offset.
+Which [Vertex Color](/vertex-options/vertex-colors.md) channel to use to control the Outline Z Offset.
 
 ### Vertex Color Strength
 
@@ -370,7 +370,7 @@ Sets how the Outline Stencil should test the depth buffer. By default, the depth
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 <ReactVideo src='/vid/outlines/outlineALtest4.mp4'/>

--- a/docs/rendering/blending.md
+++ b/docs/rendering/blending.md
@@ -5,12 +5,12 @@ description: Blending defines how the shader should blend on top of pixels that 
 keywords: [blending, render, rendering, poiyomi, shader]
 ---
 
-The Blending section defines how the shader should blend on top of pixels that are already drawn. These options are set by the [Rendering Preset](/docs/general/render-preset.md) selected at the top of the shader, and almost always need not be set manually.
+The Blending section defines how the shader should blend on top of pixels that are already drawn. These options are set by the [Rendering Preset](/general/render-preset.md) selected at the top of the shader, and almost always need not be set manually.
 
 These blend options are exposed separately for the base pass and the add pass, as the add pass needs to blend on top of the base pass.
 
 :::note Documentation Info
-Outline Blending will also be visible here containing the same settings as described here. This allows you to control the Blending operator of the [Outlines](/docs/outlines/outlines.md) separate from the base Blending.
+Outline Blending will also be visible here containing the same settings as described here. This allows you to control the Blending operator of the [Outlines](/outlines/outlines.md) separate from the base Blending.
 :::
 
 ## RGB Blend Op
@@ -23,13 +23,13 @@ Which blend operator to use for the RGB channels. This is almost always set to `
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ## RGB Destination Blend
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ## Advanced Alpha Blending
 
@@ -45,10 +45,10 @@ What blend op to use for the Alpha channel. This is typically set by the Renderi
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### Alpha Destination Blend
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.

--- a/docs/rendering/rendering.md
+++ b/docs/rendering/rendering.md
@@ -8,7 +8,7 @@ keywords: [render, rendering, cull, culling, ztest, zwrite, z, offset, instancin
 The Rendering section provides various low-level options for controlling how the shader is rendered. This plays an important part in how the Graphics Driver will interpret the shader at runtime.
 
 :::info
-Many of the settings in this section are automatically-configured depending on which [Rendering Preset](/docs/general/render-preset.md) you select.
+Many of the settings in this section are automatically-configured depending on which [Rendering Preset](/general/render-preset.md) you select.
 :::
 
 ## Cull
@@ -34,7 +34,7 @@ Learn more at [Unity's Documentation <FAIcon icon="fa-solid fa-square-arrow-up-r
 ## ZWrite
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`On`
-  - Default: Determined by [Rendering Preset](/docs/general/render-preset.md)
+  - Default: Determined by [Rendering Preset](/general/render-preset.md)
 
 Determines whether the shader should write to the depth buffer. For Opaque presets, this is usually `On`, but for Transparent presets, this is usually `Off`.
 
@@ -150,7 +150,7 @@ To do this, open the Action Menu, go to `Tools -> Avatar` and toggle the `Fallba
 The Render Queue tells Unity to set the sorting behavior within the Rendering Pipeline, as Unity must sort and draw objects within the Scene so that it can be show to the Camera as requested by the Render Queue. This plays a vital part on how the shader is rendered in-game.
 
 :::danger
-**This setting is automatically set by the [Rendering Preset](/docs/general/render-preset.md) and should not be touched!**
+**This setting is automatically set by the [Rendering Preset](/general/render-preset.md) and should not be touched!**
 
 Only modify this value if you *absolutely* know what you are doing.
 :::

--- a/docs/rendering/stencil.md
+++ b/docs/rendering/stencil.md
@@ -10,7 +10,7 @@ The Stencil section gives access to the Stencil buffer and it's associated capab
 To learn more about Stencils, visit the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Stencil.html).
 
 :::note Documentation info
-Outline Stencil will also be visible here containing the same settings as described below. This allows you to control the Stencil behavior of the [Outlines](/docs/outlines/outlines.md) separate from the base Stencil.
+Outline Stencil will also be visible here containing the same settings as described below. This allows you to control the Stencil behavior of the [Outlines](/outlines/outlines.md) separate from the base Stencil.
 :::
 
 ## Stencil Type

--- a/docs/shading/light-data.md
+++ b/docs/shading/light-data.md
@@ -5,7 +5,7 @@ description: Light Data provides technical properties that change how Lighting a
 keywords: [light, data, light data, lighting, shading, ao, shadow, mapping, masks, color, grayscale, directional, influence, poiyomi, shader]
 ---
 
-The Light Data section provides options for changing features relating to the data used for lighting and shading the material. Options here significantly influence the functionality of the [Shading](/docs/shading/main.md) section.
+The Light Data section provides options for changing features relating to the data used for lighting and shading the material. Options here significantly influence the functionality of the [Shading](/shading/main.md) section.
 
 ## AO Maps
 
@@ -18,7 +18,7 @@ The AO map texture reads all 4 RGBA channels independently, allowing different A
 Generally, if only a single map is being used (such as in the case of a black and white AO map), only one slider should generally be used. 
 
 :::note
-AO Maps are more effective in Realistic-based lighting methods (see [Shading](/docs/shading/main.md)). It may not be visible in Toon-based lighting.
+AO Maps are more effective in Realistic-based lighting methods (see [Shading](/shading/main.md)). It may not be visible in Toon-based lighting.
 :::
 
 ### AO Map R/G/B/A Strength

--- a/docs/shading/ltcgi.md
+++ b/docs/shading/ltcgi.md
@@ -19,7 +19,7 @@ For more detailed information on this system, [visit the LTCGI Documentation <FA
 This checkbox allows toggling LTCGI effects at runtime.
 
 :::tip
-LTCGI rendering is enabled by default. To turn off LTCGI in-game, you need to animate this Toggle (checkbox) when creating toggles for LTCGI on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+LTCGI rendering is enabled by default. To turn off LTCGI in-game, you need to animate this Toggle (checkbox) when creating toggles for LTCGI on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## Diffuse Tint
@@ -39,7 +39,7 @@ Color to blend multiplicatively with LTCGI to tint the reflection. Use shades of
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
   - Default: `On`
 
-When enabled, will sample the metallicity and smoothness values from [Reflections & Specular](/docs/shading/reflections-and-specular.md) for LTCGI.
+When enabled, will sample the metallicity and smoothness values from [Reflections & Specular](/shading/reflections-and-specular.md) for LTCGI.
 
 :::info
 If **Reflections & Specular** module is turned off, the **Metallic** and **Smoothness** sliders will appear below and serve as a fallback.

--- a/docs/shading/main.md
+++ b/docs/shading/main.md
@@ -6,7 +6,7 @@ keywords: [shading, diffuse, lighting, base, style, stylized, base pass, add pas
 toc_max_heading_level: 3
 ---
 
-The **Shading** section defines the base shading of the material. It controls how the material reflects light in a diffuse way, and how it is affected by other lighting. Options in the [Light Data](/docs/shading/light-data.md) section heavily affect how shading is performed.
+The **Shading** section defines the base shading of the material. It controls how the material reflects light in a diffuse way, and how it is affected by other lighting. Options in the [Light Data](/shading/light-data.md) section heavily affect how shading is performed.
 
 <a>
 <img src="/img/shading/Shading_All.png" alt="Various Shading Styles on multiple Material Spheres."/>
@@ -666,7 +666,7 @@ Smoothness is a baked-in value determining how much additional reflection the ma
 Cloth shading is a physically-based lighting model that draws from the Cloth shading model used in [Google's Filament engine](https://google.github.io/filament/Materials.html#materialmodels/clothmodel). It uses a packed mask to determine physically-based components of the lighting.
 
 :::info Cloth PBR is Built-In
-Cloth shading has Reflections & Specular already built-in. Therefore, it's <u>not necessary</u> to use both Cloth shading and [Reflections & Specular](/docs/shading/reflections-and-specular.md) at the same time!
+Cloth shading has Reflections & Specular already built-in. Therefore, it's <u>not necessary</u> to use both Cloth shading and [Reflections & Specular](/shading/reflections-and-specular.md) at the same time!
 :::
 
 <details>
@@ -751,7 +751,7 @@ This value is multiplied with the value of the Smoothness Map. If no smoothness 
 SDF (Signed Distance Field) is a complex shading style that defines how shadows should act based on the direction of light. This can create cell-looking shadows in a way similar to how Mihoyoverse renders their models (Genshin Impact, Zenless Zone Zero, etc.)
 
 :::warning SDF is NOT universal
-In a similar fashion to having a [Shadow Map](/docs/shading/light-data.md#shadow-map), SDF requires a specialized data texture, specific to your model, in order for the appearance of SDF to appear as intended.
+In a similar fashion to having a [Shadow Map](/shading/light-data.md#shadow-map), SDF requires a specialized data texture, specific to your model, in order for the appearance of SDF to appear as intended.
 
 Therefore, the results will appear "flat" if there is no texture defined.
 :::
@@ -848,10 +848,10 @@ Makes the Add Pass Lighting match close to your [Lighting Type (Base Pass)](#lig
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-If set, will send the Lighting data to a [Global Mask](/docs/modifiers/global-masks.md) of your choice as a mask. This will make the data written to the Global Mask appear based on it's illumination from the environment.
+If set, will send the Lighting data to a [Global Mask](/modifiers/global-masks.md) of your choice as a mask. This will make the data written to the Global Mask appear based on it's illumination from the environment.
 
 ### Inversed LightMap to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-If set, will send inverted Lighting data to a [Global Mask](/docs/modifiers/global-masks.md) of your choice as a mask. This is similar to the above option, but it will invert the data instead.
+If set, will send inverted Lighting data to a [Global Mask](/modifiers/global-masks.md) of your choice as a mask. This is similar to the above option, but it will invert the data instead.

--- a/docs/shading/matcap.md
+++ b/docs/shading/matcap.md
@@ -251,7 +251,7 @@ Enables hue shifting of the matcap texture.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -346,7 +346,7 @@ How much to Blend the result.
 Allows Audio Link to influence the Matcap.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Alpha Band

--- a/docs/shading/rim-lighting.md
+++ b/docs/shading/rim-lighting.md
@@ -185,7 +185,7 @@ Enables the Hue Shift feature in Rim Lighting.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -232,18 +232,18 @@ Controls how much to Apply the Rim to your Alpha.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Choose to use a [Global Mask](/docs/modifiers/global-masks.md) to constrain the Rim Lighting to the specified Mask instead. Overrides [Mask & Bias](#mask--bias).
+Choose to use a [Global Mask](/modifiers/global-masks.md) to constrain the Rim Lighting to the specified Mask instead. Overrides [Mask & Bias](#mask--bias).
 
 ### Apply to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Allows you to add the currently set Rim Lighting setup to be applied to an existing [Global Mask](/docs/modifiers/global-masks.md) of your choice.
+Allows you to add the currently set Rim Lighting setup to be applied to an existing [Global Mask](/modifiers/global-masks.md) of your choice.
 
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 <ReactVideo src='/vid/shading/RL_AudioLink.mp4'/>

--- a/docs/shading/ssao.md
+++ b/docs/shading/ssao.md
@@ -27,7 +27,7 @@ SSAO is a performance heavy effect, so use it mindfully. Add a toggle for [Anima
 This checkbox allows toggling SSAO at runtime.
 
 :::tip
-SSAO rendering is enabled by default. To turn off SSAO in-game, you need to animate this Toggle (checkbox) when creating toggles for SSAO on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+SSAO rendering is enabled by default. To turn off SSAO in-game, you need to animate this Toggle (checkbox) when creating toggles for SSAO on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## AO Intensity
@@ -171,10 +171,10 @@ Reduce these if your AO looks like it's "reaching too far". X determines the dif
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply to SSAO.
+Select which [Global Mask](/modifiers/global-masks.md) to apply to SSAO.
 
 ### Apply To Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) SSAO writes to.
+Select which [Global Mask](/modifiers/global-masks.md) SSAO writes to.

--- a/docs/shading/stylized-reflections.md
+++ b/docs/shading/stylized-reflections.md
@@ -7,7 +7,7 @@ toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---
 
-Stylized Reflections is a module that applies a stylized specular highlight or reflective effect to the material. It's useful for creating a more toon-like, stylized effect than the standard specular highlights or reflections from [Reflections & Specular](/docs/shading/reflections-and-specular.md).
+Stylized Reflections is a module that applies a stylized specular highlight or reflective effect to the material. It's useful for creating a more toon-like, stylized effect than the standard specular highlights or reflections from [Reflections & Specular](/shading/reflections-and-specular.md).
 
 :::info Changes in 9.1
 All features of the previously-named module, Stylized Specular, was merged into the [UnityChan](#unity-chan-specular) Mode documented below.

--- a/docs/shading/subsurface-scattering.md
+++ b/docs/shading/subsurface-scattering.md
@@ -84,4 +84,4 @@ Sets the intensity of shadows in Subsurface Scattering.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply directly onto the Decal.
+Select which [Global Mask](/modifiers/global-masks.md) to apply directly onto the Decal.

--- a/docs/special-fx/constellation.md
+++ b/docs/special-fx/constellation.md
@@ -115,13 +115,13 @@ Mask texture that limits where the constellation should only appear in. Black is
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Uses a [Global Mask](/docs/modifiers/global-masks.md) to limit where the constellation should only appear in.
+Uses a [Global Mask](/modifiers/global-masks.md) to limit where the constellation should only appear in.
 
 ## Write to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-If set, constellations will write onto the selected [Global Mask](/docs/modifiers/global-masks.md) channel.
+If set, constellations will write onto the selected [Global Mask](/modifiers/global-masks.md) channel.
 
 ## Random Colors
 
@@ -148,7 +148,7 @@ Sets the range of value/brightness to apply to the constellations at random inte
 Enables Audio Link features on Constellation.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Emission Band

--- a/docs/special-fx/dissolve.md
+++ b/docs/special-fx/dissolve.md
@@ -102,7 +102,7 @@ A color tint blended multiplicative with the dissolved texture.
 :::tip
 If you set the Alpha channel of this color to `A = 0`, the Dissolve can transition from the base color to Transparency.
 
-**Keep in mind this only works if you set your [Rendering Preset](/docs/general/render-preset.md) to Cutout or a Transparent Preset.**
+**Keep in mind this only works if you set your [Rendering Preset](/general/render-preset.md) to Cutout or a Transparent Preset.**
 :::
 
 <ReactVideo src='/vid/special-fx/Dissolve_DissolvedColor.mp4'/>
@@ -180,19 +180,19 @@ A black and white (single channel) mask that controls where to apply the dissolv
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use as the Dissolve Mask instead.
+Select which [Global Mask](/modifiers/global-masks.md) to use as the Dissolve Mask instead.
 
 ### Dissolved to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-This allows you to select which [Global Mask](/docs/modifiers/global-masks.md) to affect when it is fully Dissolved.
+This allows you to select which [Global Mask](/modifiers/global-masks.md) to affect when it is fully Dissolved.
 
 ### Undissolved to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-This allows you to select which [Global Mask](/docs/modifiers/global-masks.md) to affect when it is NOT Dissolved whatsoever.
+This allows you to select which [Global Mask](/modifiers/global-masks.md) to affect when it is NOT Dissolved whatsoever.
 
 ### VertexColor Mask
 
@@ -223,7 +223,7 @@ At a value of 1, the dissolve will complete a full cycle (from `0` to `1` to `0`
 Enables Audio Link to control Dissolve.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Dissolve Alpha Band
@@ -396,7 +396,7 @@ Enables/Disables hue shifting features for dissolve. Unlike most sections, this 
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -437,7 +437,7 @@ Enables or disables hue shifting of the the dissolve edge color.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Edge Select or Shift
 
@@ -475,7 +475,7 @@ Allows an alternative way to use UV Tile Discard with the use of Dissolve's effe
 If you prefer to use UV Tile Discard in a way that allows a sleek animation transition, this is the section to do it.
 
 :::info Refer to UV Tile Documentation
-All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
+All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
 
 Each Slider will control the [Dissolve Alpha](#dissolve-alpha) for the described Row and Column.
 :::
@@ -497,7 +497,7 @@ Enforces the Dissolve Tiles to be discarded once a UV Tile Dissolve reaches `1` 
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `-1.0 - 1.0`
 
-This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
+This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
 
 |  | Column 0 | Column 1 | Column 2 | Column 3 |
 | :---: | :---: | :---: | :---: | :---: |

--- a/docs/special-fx/emission.md
+++ b/docs/special-fx/emission.md
@@ -31,7 +31,7 @@ Please be aware that Fallback Shaders do not support Masking. If you are using *
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use as the Emission Mask instead.
+Select which [Global Mask](/modifiers/global-masks.md) to use as the Emission Mask instead.
 
 Expand the **Emission Mask** slot from above to see this property.
 
@@ -107,7 +107,7 @@ Enables hue shifting of the emission.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -289,7 +289,7 @@ An offset applied to the wave. This value is unit-less, and depends on the veloc
 Enables or disables Emission Audio Link features.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Strength Multiplier

--- a/docs/special-fx/flipbook.md
+++ b/docs/special-fx/flipbook.md
@@ -43,7 +43,7 @@ Defines where on the UV the flipbook can be applied. Black indicates the flipboo
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use for the Flipbook overall.
+Select which [Global Mask](/modifiers/global-masks.md) to use for the Flipbook overall.
 
 :::note
 Expand the **Mask** slot to see this property.
@@ -74,7 +74,7 @@ Optional setting to control if the Color and/or Alpha of the Flipbook should rep
 Replaces the base color with the Flipbook.
 
 :::tip
-You may animate this slider to toggle the Flipbook on the Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+You may animate this slider to toggle the Flipbook on the Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## Emission Strength
@@ -226,7 +226,7 @@ Enable or Disable the Hue Shifting functionality.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -260,7 +260,7 @@ This value is circular, and will have the same result at 0 and 1.
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Scale Band

--- a/docs/special-fx/glitter.md
+++ b/docs/special-fx/glitter.md
@@ -311,7 +311,7 @@ Increasing this value will scale the brightness of the glitter based on the inte
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use to mask the Glitter effects.
+Select which [Global Mask](/modifiers/global-masks.md) to use to mask the Glitter effects.
 
 ## Hue Shift
 
@@ -325,7 +325,7 @@ Enables or Disables the Hue Shift effect for glitter.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -361,7 +361,7 @@ How much to shift the base color around the hue circle. This value is circular, 
 Enables or Disables Audio Link effects for Glitter.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Alpha Band

--- a/docs/special-fx/internal-parallax.md
+++ b/docs/special-fx/internal-parallax.md
@@ -103,7 +103,7 @@ Enables the Hue Shift feature of the Internal Parallax.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 

--- a/docs/special-fx/pathing.md
+++ b/docs/special-fx/pathing.md
@@ -72,7 +72,7 @@ If enabled, multiplies the base alpha of the material with the Path's final alph
 
 Defines the gradients for the path. If using `Split Channels` mode, this texture should consist of between 1 and 4 channels of gradient data, with each channel representing a different path. Each channel used will flow between a value of `1` to a value of `255` (in 0-255 range), and should be defined from linear textures. 
 
-When expanded, 4 slots will be visible, one for each path. This is an integrated [Thry Texture Packer](/docs/thryeditor/thryeditor.md#texture-packer), which you can use to define gradient paths for each channel.
+When expanded, 4 slots will be visible, one for each path. This is an integrated [Thry Texture Packer](/thryeditor/thryeditor.md#texture-packer), which you can use to define gradient paths for each channel.
 
 If using `Merged Channels` mode, this texture should be the output of the Poiyomi Pathing tool. The 4 channels will be sampled in order, from `R -> G -> B -> A`.
 
@@ -202,7 +202,7 @@ Adjusts the mapping range of the specified Path.
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 For any audio link values with a **Vector2** offset, the **X** represents the value to add when the audio is at minimum (no audio), and the **Y** represents the value to add when the audio is at maximum (full audio).

--- a/docs/special-fx/proximity-color.md
+++ b/docs/special-fx/proximity-color.md
@@ -50,5 +50,5 @@ Distance from the camera at which the [Max Color](#max-color) should be applied.
 If enabled, applies the above set [Min Color](#min-color) to show on the Back Face, as if the Camera is going inside the mesh.
 
 :::caution Disable Culling for this setting to work
-In order to use **Force BackFace Color**, you must set the [Cull](/docs/rendering/rendering.md#cull) to `Off` under your [Rendering](/docs/rendering/rendering.md) settings.
+In order to use **Force BackFace Color**, you must set the [Cull](/rendering/rendering.md#cull) to `Off` under your [Rendering](/rendering/rendering.md) settings.
 :::

--- a/docs/special-fx/truchet.md
+++ b/docs/special-fx/truchet.md
@@ -97,7 +97,7 @@ If enabled, will override the Alpha/Transparency from the Base, if Transparency 
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Hide When No AL

--- a/docs/special-fx/uv-tile-discard.md
+++ b/docs/special-fx/uv-tile-discard.md
@@ -52,11 +52,11 @@ When a box is checked, that tile is discarded. When animating these Toggle check
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Face Discard is a granular alternative to the [Cull](/docs/rendering/rendering.md#cull) rendering option, providing control over which faces of a mesh to discard. It utilizes the pixel mode of UV Tile Discard to apply face discarding selectively, instead of applying global face culling across the entire material.
+Face Discard is a granular alternative to the [Cull](/rendering/rendering.md#cull) rendering option, providing control over which faces of a mesh to discard. It utilizes the pixel mode of UV Tile Discard to apply face discarding selectively, instead of applying global face culling across the entire material.
 
 This is useful when some backfaces are visible, such as in exposed interior areas of clothing, while others are not and can be discarded to improve performance. Using Face Discard in these cases lets you achieve performance gains without the limitations of enabling global culling.
 
-However, it’s important to note that while Face Discard provides more granular control compared to traditional face culling, it does not offer the same level of performance improvement as the global [Cull](/docs/rendering/rendering.md#cull) render option, which should be used when possible. This is due the discarding being performed in the fragment shader.
+However, it’s important to note that while Face Discard provides more granular control compared to traditional face culling, it does not offer the same level of performance improvement as the global [Cull](/rendering/rendering.md#cull) render option, which should be used when possible. This is due the discarding being performed in the fragment shader.
 
 ### Face Discard UV
 

--- a/docs/special-fx/voronoi.md
+++ b/docs/special-fx/voronoi.md
@@ -41,7 +41,7 @@ Determines where to contain the Voronoi effects and where it should only appear 
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Same as above, but uses a [Global Mask](/docs/modifiers/global-masks.md) instead to determine the Mask.
+Same as above, but uses a [Global Mask](/modifiers/global-masks.md) instead to determine the Mask.
 
 ## Noise
 
@@ -124,7 +124,7 @@ Minimum and Maximum range of Brightness to apply to each randomized Voronoi Cell
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Inner Emission Band

--- a/docs/thryeditor/presets.md
+++ b/docs/thryeditor/presets.md
@@ -75,7 +75,7 @@ Once you reach this part, you are now ready to start marking properties on the M
 
 ### Tagging Preset Properties
 
-In a similar manner to [Marking Properties as Animated](/docs/general/locking.md#marking-properties-for-animation), `Right-Click` and in the context menu you will instead click `Is part of preset`. When you do this, a Light Blue colored `P` symbol will appear to the left next to it. This indicates that the property will be used in your Preset. Do this for each Property that you wish to use in your Preset.
+In a similar manner to [Marking Properties as Animated](/general/locking.md#marking-properties-for-animation), `Right-Click` and in the context menu you will instead click `Is part of preset`. When you do this, a Light Blue colored `P` symbol will appear to the left next to it. This indicates that the property will be used in your Preset. Do this for each Property that you wish to use in your Preset.
 
 <a>
 <img src="/img/thryeditor/Thry_MarkingPresets.png" alt="Tagging Properties as part of the Preset" width="400px"/>
@@ -88,7 +88,7 @@ Once you finish marking your Properties as `P`, test it out by going to a Materi
 Just like as described in [Using Presets](#using-presets), open the Preset List by pressing the **Presets** button, and your Preset should be seen in there. Select your Preset and Apply to your Material. That's it!
 
 :::warning
-Be careful when creating too many Preset Materials in your project. Otherwise, you may risk causing the [64 Slot Crash](/docs/general/textures-64-texture-slot-crash.md)!
+Be careful when creating too many Preset Materials in your project. Otherwise, you may risk causing the [64 Slot Crash](/general/textures-64-texture-slot-crash.md)!
 
 To help counteract against this, you can safely switch your Preset Material(s) to the Standard shader. Don't worry, your preset settings are preserved on the Material (.mat) file. So if you need to edit your presets again later on, simply switch it back to Poiyomi and your settings will appear exactly where you left it.
 :::

--- a/docs/thryeditor/settings.md
+++ b/docs/thryeditor/settings.md
@@ -67,7 +67,7 @@ Enabled by default, ThryEditor will attempt to automatically mark properties as 
 - `Setting`: **Toggle**
   - Default: `Off`
 
-Allows a custom suffix to be used on properties that are marked Renamed Animated (`RA`), overriding the default naming as outlined [here](/docs/general/locking.md#rename-animated).
+Allows a custom suffix to be used on properties that are marked Renamed Animated (`RA`), overriding the default naming as outlined [here](/general/locking.md#rename-animated).
 
 ### Gradient Save File Names
 

--- a/docs/thryeditor/thryeditor.md
+++ b/docs/thryeditor/thryeditor.md
@@ -48,7 +48,7 @@ Right Clicking opens the Quick Presets context menu. Here you can only select on
 
 *Right-Click the Presets button to quickly select a Preset.*
 
-You can also create your own Presets using this feature. [See the Documentation Page to learn more.](/docs/thryeditor/presets.md)
+You can also create your own Presets using this feature. [See the Documentation Page to learn more.](/thryeditor/presets.md)
 
 ### Material Linking
 
@@ -86,7 +86,7 @@ In each Texture Slot, a number will appear on the right-hand side of the Texture
 
 This number informs the user on how much Texture Memory (VRAM) that the assigned Texture is expected to consume. The amount indicated can greatly impact how other users load your Avatar's texture when it is being rendered on their end.
 
-To learn more about how Texture Memory impacts performance, [see this page](/docs/general/textures-and-colors.md#vram-usage).
+To learn more about how Texture Memory impacts performance, [see this page](/general/textures-and-colors.md#vram-usage).
 
 <a>
 <img src="/img/thryeditor/TextureVRAMText.png" alt="Estimated VRAM on the assigned Texture" width="700px"/>
@@ -98,7 +98,7 @@ Configurable in ThryEditor Settings, an asterisk (`*`) will appear next to a Mat
 
 ### VRChat Fallback Shader
 
-The Fallback Shader option generates a tag for the material that informs VRChat which shader to use when your shaders are hidden. See [Rendering: VRChat Fallback Shader](/docs/rendering/rendering.md#vrchat-fallback-shader) for more details.
+The Fallback Shader option generates a tag for the material that informs VRChat which shader to use when your shaders are hidden. See [Rendering: VRChat Fallback Shader](/rendering/rendering.md#vrchat-fallback-shader) for more details.
 
 <a>
 <img src="/img/thryeditor/fallback.png" alt="VRC Fallback Selector" width="700px"/>

--- a/docs/vertex-options/basics.md
+++ b/docs/vertex-options/basics.md
@@ -209,7 +209,7 @@ Determines the bottom lower height of the funnel.
 Enables the ability to manipulate the Vertex Options in response to Audio Link.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 <ReactVideo src='/vid/color-and-normals/VertexOptionsAudioLink.webm'/>

--- a/docs/vertex-options/glitching.md
+++ b/docs/vertex-options/glitching.md
@@ -75,7 +75,7 @@ Enables the ability to control the visibility of the glitching in mirrors.
 Enables the ability to use Audio Link to control the Glitching Intensity.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Glitch Band

--- a/docs/vertex-options/look-at.md
+++ b/docs/vertex-options/look-at.md
@@ -71,7 +71,7 @@ The following properties below will appear for each Color Mask you are customizi
 Controls the overall visibility of the LookAt effect. `0` would be no effect, `0.5` would be half of the effect, and `1.0` would be the full effect.
 
 :::tip
-Animate this slider when creating toggles for LookAt on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+Animate this slider when creating toggles for LookAt on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ### Target Up Direction
@@ -138,7 +138,7 @@ Clamps the maximum rotational Roll of the affected mask on the Z-axis (Barrel Ro
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**WW
 
-Enables the visibility modifier, which includes features similar to the [Mirror/Camera Visibility](/docs/special-fx/mirror.md) feature. This can affect how LookAt appears either Normally, in the Mirror, or in the Camera.
+Enables the visibility modifier, which includes features similar to the [Mirror/Camera Visibility](/special-fx/mirror.md) feature. This can affect how LookAt appears either Normally, in the Mirror, or in the Camera.
 
 Use this section to specifically control how LookAt should appear in specific scenarios.
 
@@ -214,10 +214,10 @@ Mode to use for the LookAt visibility.
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Enables [Audio Link](/docs/audio-link/audio-link.md) to control LookAt. This will affect ALL `Alpha` properties in LookAt.
+Enables [Audio Link](/audio-link/audio-link.md) to control LookAt. This will affect ALL `Alpha` properties in LookAt.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Alpha Band

--- a/docs/vertex-options/vertex-colors.md
+++ b/docs/vertex-options/vertex-colors.md
@@ -7,7 +7,7 @@ keywords: [vertex, colors, vertex colors, linear, alpha, poiyomi, shader]
 
 The Vertex Colors section provides options for using a Mesh's Vertex Colors to affect the Base color and Alpha. Vertex Colors are determined by the embedded Color Attributes of a Mesh, which were painted on from 3D Software such as Blender.
 
-Vertex Colors can also be used as Masks in different parts of the Shader, such as [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md#vertex-colors) and [Global Masks](/docs/modifiers/global-masks.md#vertex-colors).
+Vertex Colors can also be used as Masks in different parts of the Shader, such as [RGBA Color Masking](/color-and-normals/rgba-color-masking.md#vertex-colors) and [Global Masks](/modifiers/global-masks.md#vertex-colors).
 
 <ReactVideo src='/vid/color-and-normals/PoiVertexColors.webm'/>
 <em>This video shows how the shader will read Vertex Colors if the Mesh itself has assigned Color Attributes.</em>

--- a/docs/vertex-options/view-clip-prevention.md
+++ b/docs/vertex-options/view-clip-prevention.md
@@ -17,7 +17,7 @@ View Clip Prevention (also known as the [Uzumore Shader <FAIcon icon="fa-solid f
 This is used to globally toggle the Uzumore Shader's effect across the entire material.
 
 :::tip Reminder
-Make sure to tag this checkbox as animated if creating toggles for this feature. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work! [Read More](/docs/general/locking.md#marking-properties-for-animation)
+Make sure to tag this checkbox as animated if creating toggles for this feature. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work! [Read More](/general/locking.md#marking-properties-for-animation)
 :::
 
 ## Push Amount (m)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,6 +25,19 @@ export default {
     }
   },
 
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'ru'],
+    localeConfigs: {
+      en: {
+        htmlLang: 'en-US',
+      },
+      ru: {
+        htmlLang: 'ru-RU',
+      }
+    },
+  },
+
   future: {
     experimental_faster: true,
     v4: true,

--- a/i18n/ru/code.json
+++ b/i18n/ru/code.json
@@ -1,0 +1,364 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "На странице произошёл сбой.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Прокрутка к началу",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Архив",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Архив",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Навигация по странице списка блогов",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Следующие записи",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Предыдущие записи",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Навигация по странице поста блога",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Следующий пост",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Предыдущий пост",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Посмотреть все теги",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "Светлый режим",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "Тёмный режим",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Переключение между темным и светлым режимом (сейчас используется {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Навигационная цепочка текущей страницы",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} элемент|{count} элемента|{count} элементов",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Страница документа",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Предыдущая страница",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Следующая страница",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Одна страница|{count} страницы|{count} страниц",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} с тегом \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Это документация для будущей версии {siteTitle} {versionLabel}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Это документация {siteTitle} для версии {versionLabel}, которая уже не поддерживается.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Актуальная документация находится на странице {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "последней версии",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Версия: {versionLabel}"
+  },
+  "theme.common.editThisPage": {
+    "message": "Отредактировать эту страницу",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Прямая ссылка на {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " от {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Последнее обновление{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Версии",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "Страница не найдена",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Теги:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "предупреждение",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "осторожно",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "к сведению",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "примечание",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "подсказка",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "warning",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Закрыть",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Навигация по последним постам в блоге",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expand sidebar category '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Collapse sidebar category '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "К сожалению, мы не смогли найти запрашиваемую вами страницу.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Пожалуйста, обратитесь к владельцу сайта, с которого вы перешли на эту ссылку, чтобы сообщить ему, что ссылка не работает.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Языки",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Содержание этой страницы",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Читать дальше",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Подробнее о {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "{readingTime} мин. чтения|{readingTime} мин. чтения|{readingTime} мин. чтения",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Скопировать",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Скопировано",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Скопировать в буфер обмена",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Переключить перенос по строкам",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Главная страница",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Свернуть сайдбар",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Свернуть сайдбар",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Закрыть панель навигации",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Перейти к главному меню",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Переключить навигационную панель",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Развернуть сайдбар",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Развернуть сайдбар",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.noResultsText": {
+    "message": "No results"
+  },
+  "theme.SearchBar.seeAllOutsideContext": {
+    "message": "See all results outside \"{context}\""
+  },
+  "theme.SearchBar.searchInContext": {
+    "message": "See all results within \"{context}\""
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "See all results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Search",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Search results for \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Search the documentation",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.searchContext.everywhere": {
+    "message": "Everywhere"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "1 document found|{count} documents found",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "No documents were found",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count} запись|{count} записи|{count} записей",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} с тегом \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Authors",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "View All Authors",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "This author has not written any posts yet.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Unlisted page",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Попробуйте ещё раз",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Перейти к основному содержимому",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Теги",
+    "description": "The title of the tag list page"
+  }
+}

--- a/i18n/ru/docusaurus-plugin-content-blog-second-blog/options.json
+++ b/i18n/ru/docusaurus-plugin-content-blog-second-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Changelog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "All Changelogs from the latest versions of Poiyomi Shaders.",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "All Changelogs",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/ru/docusaurus-plugin-content-blog/options.json
+++ b/i18n/ru/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "All Posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/ru/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ru/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,62 @@
+{
+  "version.label": {
+    "message": "10.0",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.General Information": {
+    "message": "General Information",
+    "description": "The label for category 'General Information' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Upgrade": {
+    "message": "Upgrade",
+    "description": "The label for category 'Upgrade' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Color & Normals": {
+    "message": "Color & Normals",
+    "description": "The label for category 'Color & Normals' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Shading": {
+    "message": "Shading",
+    "description": "The label for category 'Shading' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Special FX": {
+    "message": "Special FX",
+    "description": "The label for category 'Special FX' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Audio Link": {
+    "message": "Audio Link",
+    "description": "The label for category 'Audio Link' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Vertex Options": {
+    "message": "Vertex Options",
+    "description": "The label for category 'Vertex Options' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Global Modifiers & Data": {
+    "message": "Global Modifiers & Data",
+    "description": "The label for category 'Global Modifiers & Data' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.UVs": {
+    "message": "UVs",
+    "description": "The label for category 'UVs' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Post Processing": {
+    "message": "Post Processing",
+    "description": "The label for category 'Post Processing' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Extended Features": {
+    "message": "Extended Features",
+    "description": "The label for category 'Extended Features' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Rendering": {
+    "message": "Rendering",
+    "description": "The label for category 'Rendering' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Thry Editor": {
+    "message": "Thry Editor",
+    "description": "The label for category 'Thry Editor' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.TPS": {
+    "message": "TPS",
+    "description": "The label for category 'TPS' in sidebar 'tutorialSidebar'"
+  }
+}

--- a/i18n/ru/docusaurus-plugin-content-docs/version-9.3.json
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-9.3.json
@@ -1,0 +1,62 @@
+{
+  "version.label": {
+    "message": "9.3",
+    "description": "The label for version 9.3"
+  },
+  "sidebar.tutorialSidebar.category.General Information": {
+    "message": "General Information",
+    "description": "The label for category 'General Information' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Upgrade": {
+    "message": "Upgrade",
+    "description": "The label for category 'Upgrade' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Color & Normals": {
+    "message": "Color & Normals",
+    "description": "The label for category 'Color & Normals' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Shading": {
+    "message": "Shading",
+    "description": "The label for category 'Shading' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Special FX": {
+    "message": "Special FX",
+    "description": "The label for category 'Special FX' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Audio Link": {
+    "message": "Audio Link",
+    "description": "The label for category 'Audio Link' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Vertex Options": {
+    "message": "Vertex Options",
+    "description": "The label for category 'Vertex Options' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Global Modifiers & Data": {
+    "message": "Global Modifiers & Data",
+    "description": "The label for category 'Global Modifiers & Data' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.UVs": {
+    "message": "UVs",
+    "description": "The label for category 'UVs' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Post Processing": {
+    "message": "Post Processing",
+    "description": "The label for category 'Post Processing' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Extended Features": {
+    "message": "Extended Features",
+    "description": "The label for category 'Extended Features' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Rendering": {
+    "message": "Rendering",
+    "description": "The label for category 'Rendering' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Thry Editor": {
+    "message": "Thry Editor",
+    "description": "The label for category 'Thry Editor' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.TPS": {
+    "message": "TPS",
+    "description": "The label for category 'TPS' in sidebar 'tutorialSidebar'"
+  }
+}

--- a/i18n/ru/docusaurus-theme-classic/footer.json
+++ b/i18n/ru/docusaurus-theme-classic/footer.json
@@ -1,0 +1,134 @@
+{
+  "link.title.Featured Pages": {
+    "message": "Featured Pages",
+    "description": "The title of the footer links column with title=Featured Pages in the footer"
+  },
+  "link.title.Community": {
+    "message": "Community",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.Where to Download": {
+    "message": "Where to Download",
+    "description": "The title of the footer links column with title=Where to Download in the footer"
+  },
+  "link.title.About": {
+    "message": "About",
+    "description": "The title of the footer links column with title=About in the footer"
+  },
+  "link.item.label.Download & Install": {
+    "message": "Download & Install",
+    "description": "The label of footer link with label=Download & Install linking to /download"
+  },
+  "link.item.label.Locking and Animation": {
+    "message": "Locking and Animation",
+    "description": "The label of footer link with label=Locking and Animation linking to /general/locking"
+  },
+  "link.item.label.Color & Normals": {
+    "message": "Color & Normals",
+    "description": "The label of footer link with label=Color & Normals linking to /color-and-normals"
+  },
+  "link.item.label.Shading": {
+    "message": "Shading",
+    "description": "The label of footer link with label=Shading linking to /shading/main"
+  },
+  "link.item.label.Reflections & Specular": {
+    "message": "Reflections & Specular",
+    "description": "The label of footer link with label=Reflections & Specular linking to /shading/reflections-and-specular"
+  },
+  "link.item.label.Screen Space Ambient Occlusion": {
+    "message": "Screen Space Ambient Occlusion",
+    "description": "The label of footer link with label=Screen Space Ambient Occlusion linking to /shading/ssao"
+  },
+  "link.item.label.Outlines": {
+    "message": "Outlines",
+    "description": "The label of footer link with label=Outlines linking to /outlines"
+  },
+  "link.item.label.UV Tile Discard": {
+    "message": "UV Tile Discard",
+    "description": "The label of footer link with label=UV Tile Discard linking to /special-fx/uv-tile-discard"
+  },
+  "link.item.label.Emission": {
+    "message": "Emission",
+    "description": "The label of footer link with label=Emission linking to /special-fx/emission"
+  },
+  "link.item.label.Glitter / Sparkle": {
+    "message": "Glitter / Sparkle",
+    "description": "The label of footer link with label=Glitter / Sparkle linking to /special-fx/glitter"
+  },
+  "link.item.label.AudioLink": {
+    "message": "AudioLink",
+    "description": "The label of footer link with label=AudioLink linking to /audio-link"
+  },
+  "link.item.label.Global Masks": {
+    "message": "Global Masks",
+    "description": "The label of footer link with label=Global Masks linking to /modifiers/global-masks"
+  },
+  "link.item.label.Rendering": {
+    "message": "Rendering",
+    "description": "The label of footer link with label=Rendering linking to /rendering/"
+  },
+  "link.item.label.Thry Editor": {
+    "message": "Thry Editor",
+    "description": "The label of footer link with label=Thry Editor linking to /thryeditor/"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/poiyomi"
+  },
+  "link.item.label.Bluesky": {
+    "message": "Bluesky",
+    "description": "The label of footer link with label=Bluesky linking to https://bsky.app/profile/poiyomi.com"
+  },
+  "link.item.label.Twitter / X": {
+    "message": "Twitter / X",
+    "description": "The label of footer link with label=Twitter / X linking to https://x.com/poiyomi"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/poiyomi"
+  },
+  "link.item.label.BOOTH": {
+    "message": "BOOTH",
+    "description": "The label of footer link with label=BOOTH linking to https://poiyomi.booth.pm/"
+  },
+  "link.item.label.GitHub Repository": {
+    "message": "GitHub Repository",
+    "description": "The label of footer link with label=GitHub Repository linking to https://github.com/poiyomi/PoiyomiToonShader"
+  },
+  "link.item.label.BOOTH Listing": {
+    "message": "BOOTH Listing",
+    "description": "The label of footer link with label=BOOTH Listing linking to https://poiyomi.booth.pm/items/4841309"
+  },
+  "link.item.label.VCC Repository": {
+    "message": "VCC Repository",
+    "description": "The label of footer link with label=VCC Repository linking to vcc://vpm/addRepo?url=https%3A%2F%2Fpoiyomi.github.io/vpm/index.json"
+  },
+  "link.item.label.Poiyomi Pro (Requires Patreon)": {
+    "message": "Poiyomi Pro (Requires Patreon)",
+    "description": "The label of footer link with label=Poiyomi Pro (Requires Patreon) linking to https://pro.poiyomi.com/"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.FAQ / Troubleshooting": {
+    "message": "FAQ / Troubleshooting",
+    "description": "The label of footer link with label=FAQ / Troubleshooting linking to /general/faq"
+  },
+  "link.item.label.Terms of Service": {
+    "message": "Terms of Service",
+    "description": "The label of footer link with label=Terms of Service linking to /terms-of-service"
+  },
+  "link.item.label.Credits": {
+    "message": "Credits",
+    "description": "The label of footer link with label=Credits linking to /credits"
+  },
+  "copyright": {
+    "message": "Copyright © 2026 Poiyomi Labs. v2026.3.12. Built with Docusaurus.",
+    "description": "The footer copyright"
+  },
+  "logo.alt": {
+    "message": "Poiyomi Logo",
+    "description": "The alt text of footer logo"
+  }
+}

--- a/i18n/ru/docusaurus-theme-classic/navbar.json
+++ b/i18n/ru/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,54 @@
+{
+  "title": {
+    "message": "Poiyomi Shaders",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Poiyomi Circle Logo",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Download & Install": {
+    "message": "Download & Install",
+    "description": "Navbar item with label Download & Install"
+  },
+  "item.label.Blog & Updates": {
+    "message": "Blog & Updates",
+    "description": "Navbar item with label Blog & Updates"
+  },
+  "item.label.Community": {
+    "message": "Community",
+    "description": "Navbar item with label Community"
+  },
+  "item.label.Blog: Tips & Tricks": {
+    "message": "Blog: Tips & Tricks",
+    "description": "Navbar item with label Blog: Tips & Tricks"
+  },
+  "item.label.Changelogs": {
+    "message": "Changelogs",
+    "description": "Navbar item with label Changelogs"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  },
+  "item.label.Bluesky": {
+    "message": "Bluesky",
+    "description": "Navbar item with label Bluesky"
+  },
+  "item.label.Twitter / X": {
+    "message": "Twitter / X",
+    "description": "Navbar item with label Twitter / X"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "item.label.BOOTH": {
+    "message": "BOOTH",
+    "description": "Navbar item with label BOOTH"
+  }
+}

--- a/versioned_docs/version-9.3/audio-link/audio-link.md
+++ b/versioned_docs/version-9.3/audio-link/audio-link.md
@@ -24,23 +24,23 @@ If enabled, activates Audio Link features and exposes Audio Link parameter contr
 
 :::info
 When this feature activates, the following sections in Poiyomi Shaders will have their Audio Link properties exposed for you to use. Please refer to each of their Documentation Entries for more information.
-- [Color Adjust](/docs/color-and-normals/color-adjust.md#hue-shift-audio-link)
-- [Alpha Options](/docs/color-and-normals/alpha-options.md#alpha-audio-link)
-- [Decals](/docs/color-and-normals/decals.md#audio-link)
-- [Matcap](/docs/shading/matcap.md#audio-link)
-- [Rim Lighting](/docs/shading/rim-lighting.md#audio-link)
-- [Outlines](/docs/outlines/outlines.md#audio-link)
-- [Dissolve](/docs/special-fx/dissolve.md#audio-link)
-- [Flipbook](/docs/special-fx/flipbook.md#audio-link)
-- [Emission](/docs/special-fx/emission.md#audio-link)
-- [Glitter / Sparkle](/docs/special-fx/glitter.md#audio-link)
-- [Pathing](/docs/special-fx/pathing.md#audio-link)
-- [Voronoi](/docs/special-fx/voronoi.md#audio-link)
-- [Truchet](/docs/special-fx/truchet.md#audio-link)
-- [Constellation](/docs/special-fx/constellation.md#audio-link)
-- [Vertex Options -> Basics & Fun](/docs/vertex-options/basics.md#audio-link)
-- [Vertex Options -> Glitching](/docs/vertex-options/glitching.md#audio-link)
-- [Vertex Options -> LookAt](/docs/vertex-options/look-at.md#audio-link)
+- [Color Adjust](/color-and-normals/color-adjust.md#hue-shift-audio-link)
+- [Alpha Options](/color-and-normals/alpha-options.md#alpha-audio-link)
+- [Decals](/color-and-normals/decals.md#audio-link)
+- [Matcap](/shading/matcap.md#audio-link)
+- [Rim Lighting](/shading/rim-lighting.md#audio-link)
+- [Outlines](/outlines/outlines.md#audio-link)
+- [Dissolve](/special-fx/dissolve.md#audio-link)
+- [Flipbook](/special-fx/flipbook.md#audio-link)
+- [Emission](/special-fx/emission.md#audio-link)
+- [Glitter / Sparkle](/special-fx/glitter.md#audio-link)
+- [Pathing](/special-fx/pathing.md#audio-link)
+- [Voronoi](/special-fx/voronoi.md#audio-link)
+- [Truchet](/special-fx/truchet.md#audio-link)
+- [Constellation](/special-fx/constellation.md#audio-link)
+- [Vertex Options -> Basics & Fun](/vertex-options/basics.md#audio-link)
+- [Vertex Options -> Glitching](/vertex-options/glitching.md#audio-link)
+- [Vertex Options -> LookAt](/vertex-options/look-at.md#audio-link)
 :::
 
 ### Anim Toggle
@@ -50,7 +50,7 @@ When this feature activates, the following sections in Poiyomi Shaders will have
 This checkbox allows toggling Audio Link effects at runtime.
 
 :::tip
-Audio Link is enabled by default. To turn off Audio Link in-game, you need to animate this Toggle (checkbox) when creating toggles for Audio Link on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+Audio Link is enabled by default. To turn off Audio Link in-game, you need to animate this Toggle (checkbox) when creating toggles for Audio Link on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## Smoothing

--- a/versioned_docs/version-9.3/color-and-normals/alpha-options.md
+++ b/versioned_docs/version-9.3/color-and-normals/alpha-options.md
@@ -6,7 +6,7 @@ image: /img/color-and-normals/Thumb-AlphaOptions.png
 keywords: [alpha, options, properties, poiyomi, shader]
 ---
 
-The **Alpha Options** section provides options for modifying how the material treats alpha. The effects of these options are heavily influenced by the [Render Preset](/docs/general/render-preset.md) and other render settings.
+The **Alpha Options** section provides options for modifying how the material treats alpha. The effects of these options are heavily influenced by the [Render Preset](/general/render-preset.md) and other render settings.
 
 These properties below can allow you to further modify how you want the Alpha to behave on the Shader, like the Fresnel effect, Angular Alpha, Distance Fade, and more.
 
@@ -26,7 +26,7 @@ Alpha Mod defines a direct value to add to or remove from the material alpha. Th
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use for the Alpha overall.
+Select which [Global Mask](/modifiers/global-masks.md) to use for the Alpha overall.
 
 ## Alpha To Coverage
 
@@ -123,7 +123,7 @@ The distance (in meters) at which the Max Distance Alpha multiplier will be appl
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Distance Alpha / Distance Fade onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Distance Alpha / Distance Fade onto.
 
 ## Fresnel Alpha
 
@@ -131,7 +131,7 @@ Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the D
 
 Enable or Disable the Fresnel Alpha effect. Fresnel Alpha uses the angle between the viewer (camera) and the object's normal to modify the alpha.
 
-This can be used to simulate materials that are more opaque at shallow angles, such as transluscent fabric (used for tights or stockings). It can be thought of as analagous to [Rim Lighting](/docs/shading/rim-lighting.md), but for alpha instead of color.
+This can be used to simulate materials that are more opaque at shallow angles, such as transluscent fabric (used for tights or stockings). It can be thought of as analagous to [Rim Lighting](/shading/rim-lighting.md), but for alpha instead of color.
 
 ### Intensity
 
@@ -161,7 +161,7 @@ Whether the Fresnel Alpha effect should increase in intensity from the outside-i
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Fresnel Alpha effect onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Fresnel Alpha effect onto.
 
 ## Angular Alpha
 
@@ -253,7 +253,7 @@ The minimum value of alpha for the Angular Alpha mode. This will prevent the alp
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Angular Alpha effect onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Angular Alpha effect onto.
 
 ## Alpha Audio Link
 
@@ -262,7 +262,7 @@ Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the A
 Enables Audio Link for Alpha Options. The Alpha can be modified based on the audio level in a specific band.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Add Band

--- a/versioned_docs/version-9.3/color-and-normals/back-face.md
+++ b/versioned_docs/version-9.3/color-and-normals/back-face.md
@@ -10,7 +10,7 @@ Back Face provides options for modifying the base color, emission, and alpha for
 On 3D models, meshes typically only show it's faces on one side, that being the front-facing side. The back-facing side of the mesh is usually see-through, an effect that you can get when you are looking from inside a model. Shaders can control this behavior, forcing the back-facing side of the mesh to also render if the user desires for whatever reason.
 
 :::caution Disable Culling to use this feature!
-To use this section, [Cull](/docs/rendering/rendering.md#cull) must be set to `Off` in order for backfaces to be visible. Find this option under [Rendering](/docs/rendering/rendering.md).
+To use this section, [Cull](/rendering/rendering.md#cull) must be set to `Off` in order for backfaces to be visible. Find this option under [Rendering](/rendering/rendering.md).
 :::
 
 ## Color
@@ -49,7 +49,7 @@ Enable or Disable Hue Shift for the backface base color.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -86,7 +86,7 @@ How much to constantly shift the hue with time. A value of 1 will result in a fu
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `0.0 - 5.0`
 
-Detail Intensity backface multiplier for detail textures in the [Details](/docs/color-and-normals/details.md) section.
+Detail Intensity backface multiplier for detail textures in the [Details](/color-and-normals/details.md) section.
 
 ### Replace Alpha
 
@@ -98,4 +98,4 @@ Whether to replace the alpha value for the backface with the alpha calculated fr
 
 - `Type`: <PropertyIcon name="float" />**Float**
 
-Custom Multiplier to limit the [Emissions](/docs/special-fx/emission.md) shown on the backface.
+Custom Multiplier to limit the [Emissions](/special-fx/emission.md) shown on the backface.

--- a/versioned_docs/version-9.3/color-and-normals/color-adjust.md
+++ b/versioned_docs/version-9.3/color-and-normals/color-adjust.md
@@ -6,7 +6,7 @@ image: /img/color-and-normals/Thumb-ColorAdjust.png
 keywords: [hue, color, saturation, gamma, hue shift, poiyomi]
 ---
 
-The Color Adjust section provides options for modifying the base color of the material. This is applied directly after the main [Color and Normals](/docs/color-and-normals/color-and-normals.md) section, and will not affect any other sections that modify the Base Color.
+The Color Adjust section provides options for modifying the base color of the material. This is applied directly after the main [Color and Normals](/color-and-normals/color-and-normals.md) section, and will not affect any other sections that modify the Base Color.
 
 Color Adjust can be used to quickly change the colors presented from the main texture to a different hue of color either directly or indirectly. The results of the hue shift can vary depending on which [Color Space](#color-space) is chosen, and how much [Saturation](#saturation), [Brightness](#brightness), and [Gamma](#gamma), is set by the user.
 
@@ -19,7 +19,7 @@ Color Adjust can be used to quickly change the colors presented from the main te
 
 Texture Slot that defines where to specifically apply the color adjustments to. If this texture is not defined, the adjustments will apply everywhere.
 
-This slot has the [Texture Packer](/docs/thryeditor/thryeditor.md#texture-packer) integrated for convenience.
+This slot has the [Texture Packer](/thryeditor/thryeditor.md#texture-packer) integrated for convenience.
 
 | Channel | Mask |
 | :---: | :---: |
@@ -152,7 +152,7 @@ If set, will constantly shift the hue with time. A value of `1` will result in a
 If enabled, allows the Hue Shift to be controlled with Audio Link chronotensity.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 #### Band
@@ -193,7 +193,7 @@ How strong should the Color Grading be applied to the Color Adjust.
 
 ## Global Mask
 
-Use this section to instead use a [Global Mask](/docs/modifiers/global-masks.md) for the Color Adjust Mask.
+Use this section to instead use a [Global Mask](/modifiers/global-masks.md) for the Color Adjust Mask.
 
 ### Hue
 

--- a/versioned_docs/version-9.3/color-and-normals/color-and-normals.md
+++ b/versioned_docs/version-9.3/color-and-normals/color-and-normals.md
@@ -42,7 +42,7 @@ The Normal Map texture has a slider for **Intensity**, which affects how much in
 
 *Adjusting the Intensity of a Normal Map on a Shaded material*
 
-A Normal Map will affect anything that uses the Normal of a mesh (specifically the Pixel normal, as opposed to the Vertex normal, which is the normal defined by the mesh itself). This includes features like [Shading](/docs/shading/main.md), [Rim Lighting](/docs/shading/rim-lighting.md), [Reflections and Specular](/docs/shading/reflections-and-specular.md), [Matcaps](/docs/shading/matcap.md), and many other lighting-based effects.
+A Normal Map will affect anything that uses the Normal of a mesh (specifically the Pixel normal, as opposed to the Vertex normal, which is the normal defined by the mesh itself). This includes features like [Shading](/shading/main.md), [Rim Lighting](/shading/rim-lighting.md), [Reflections and Specular](/shading/reflections-and-specular.md), [Matcaps](/shading/matcap.md), and many other lighting-based effects.
 
 :::info Use OpenGL Format
 **Poiyomi Shaders, and across Unity as a whole, <u>requires OpenGL format</u> for Normal Maps.** Even though the game runs in DirectX, Unity always uses the OpenGL format.
@@ -97,4 +97,4 @@ In Transparent rendering modes like Fade, Transparent, TransClipping, etc., this
 
 <ReactVideo src='/vid/color-and-normals/main_Alpha-Cutoff_Fade.webm'/> 
 
-[^1]: [Special Unity Properties](/docs/general/locking.md#unity-special-properties)
+[^1]: [Special Unity Properties](/general/locking.md#unity-special-properties)

--- a/versioned_docs/version-9.3/color-and-normals/decals.md
+++ b/versioned_docs/version-9.3/color-and-normals/decals.md
@@ -149,7 +149,7 @@ Which blending operation to use from the Decal's Alpha channel.
 How much to apply the blended color to the base color.
 
 :::tip
-This slider can be animated to hide and show the decal. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+This slider can be animated to hide and show the decal. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ### Depth
@@ -170,7 +170,7 @@ Enable or Disable hue shifting of the Decal.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 #### Select or Shift
 
@@ -220,7 +220,7 @@ This feature enables a Video Texture to appear on the Decal. It will only work i
 <details>
 <summary><b>How to test Decal Video Textures</b></summary>
 
-1. Ensure you have the `AudioLinkAvatar` Prefab in your Scene, as described [here](/docs/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders).
+1. Ensure you have the `AudioLinkAvatar` Prefab in your Scene, as described [here](/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders).
 2. Inside the `AudioLinkAvatar` Prefab, expand it and select the object `AudioLinkYtdlpPlayer`. *This is the same place where you specify a YouTube video to use when testing Audio Link.*
 3. On the bottom line, **enable** the checkmark called `Enable Global Video Texture`.
 4. The Decal Video Texture can now be tested and debugged in the Unity Editor while in Play Mode.
@@ -309,18 +309,18 @@ Choice of where the Decal should appear on your Normals. You can choose it to ap
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply directly onto the Decal.
+Select which [Global Mask](/modifiers/global-masks.md) to apply directly onto the Decal.
 
 #### Apply To Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to send your Decal's effects onto the specified Global Mask.
+Select which [Global Mask](/modifiers/global-masks.md) to send your Decal's effects onto the specified Global Mask.
 
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Scale Band

--- a/versioned_docs/version-9.3/color-and-normals/details.md
+++ b/versioned_docs/version-9.3/color-and-normals/details.md
@@ -51,7 +51,7 @@ Multiplier for the detail texture's base brightness. Can be used to emphasize da
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Detail Texture onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Detail Texture onto.
 
 ## Detail Normal
 
@@ -71,4 +71,4 @@ Intensity multiplier for the detail normal map. Expand the Detail Normal texture
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to only affect the Detail Normal onto.
+Select which [Global Mask](/modifiers/global-masks.md) to only affect the Detail Normal onto.

--- a/versioned_docs/version-9.3/color-and-normals/rgba-color-masking.md
+++ b/versioned_docs/version-9.3/color-and-normals/rgba-color-masking.md
@@ -37,7 +37,7 @@ Use a Texture Mask to set the RGBA Mask. If enabled, it exposes the [Masks](#mas
 
 ### Vertex Colors
 
-Use the mesh's [Vertex Colors](/docs/vertex-options/vertex-colors.md) to set the RGBA Mask.
+Use the mesh's [Vertex Colors](/vertex-options/vertex-colors.md) to set the RGBA Mask.
 
 :::note Linear Vertex Colors Recommended
 When using Vertex Colors as the RGBA Mask, make sure the Color Attributes on the Mesh are in **Linear** Color so that the shader can accurately read them.

--- a/versioned_docs/version-9.3/download/download.md
+++ b/versioned_docs/version-9.3/download/download.md
@@ -139,7 +139,7 @@ The VCC version of Poiyomi Shaders will automatically replace any existing copy 
 
 The Pro version of the shader (also known as Poiyomi Pro) is a Paid Version of the shader, available as a subscription model for $10/month on Patreon. It contains extra special features that are [outlined below](#features-chart).
 
-Before using Poiyomi Pro, please ensure you agree to the [EULA](/docs/terms-of-service/terms-of-service.md#pro-version).
+Before using Poiyomi Pro, please ensure you agree to the [EULA](/terms-of-service/terms-of-service.md#pro-version).
 
 <div style={{marginBottom: '20px'}}>
 
@@ -181,7 +181,7 @@ Things work a little differently when using this version upon launching your Uni
 
 Do keep in mind that this script is intentionally designed to require an active subscription in order to receive future updates. So when updating Poiyomi Pro, you must go through the same process as detailed above.
 
-By using Poiyomi Pro, you agree to the EULA stated [here](/docs/terms-of-service/terms-of-service.md#pro-version).
+By using Poiyomi Pro, you agree to the EULA stated [here](/terms-of-service/terms-of-service.md#pro-version).
 
 ### Features Chart
 
@@ -190,44 +190,44 @@ To see the different features offered between the Free vs. Pro version, refer to
 | Role Access | Public | $2/month | $5/month | $10/month | $20/month | $50/month |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: |
 | **Toon/Pro Features** | | Nano | Micro | Mega | Giga | Tera |
-| [Color & Normals](/docs/color-and-normals/color-and-normals.md), [Color Adjust (Hue Shift)](/docs/color-and-normals/color-adjust.md), [Details](/docs/color-and-normals/details.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Alpha Options](/docs/color-and-normals/alpha-options.md), [Back Face](/docs/color-and-normals/back-face.md), [Normal Correct](/docs/color-and-normals/normal-correct.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Decals](/docs/color-and-normals/decals.md), [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Anisotropics](/docs/shading/anisotropics.md), [Matcaps](/docs/shading/matcap.md), [CubeMap](/docs/shading/cubemap.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Rim Lighting](/docs/shading/rim-lighting.md), [Depth Rim Lighting](/docs/shading/depth-rim-lighting.md), [Subsurface Scattering](/docs/shading/subsurface-scattering.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Reflections & Specular](/docs/shading/reflections-and-specular.md), [Clear Coat](/docs/shading/clear-coat.md), [Environmental Rim](/docs/shading/environmental-rim.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Stylized Reflections](/docs/shading/stylized-reflections.md), [Backlight](/docs/shading/backlight.md), [LTCGI](/docs/shading/ltcgi.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Outlines](/docs/outlines/outlines.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), [Proximity Color](/docs/special-fx/proximity-color.md), [Mirror/Camera Visibility](/docs/special-fx/mirror.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Depth Bulge](/docs/special-fx/depth-bulge.md), [Depth FX](/docs/special-fx/depth-fx.md), [Internal Parallax](/docs/special-fx/internal-parallax.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Emissions](/docs/special-fx/emission.md), [Glitter/Sparkle](/docs/special-fx/glitter.md), [Dissolve](/docs/special-fx/dissolve.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Flipbook](/docs/special-fx/flipbook.md), [Pathing](/docs/special-fx/pathing.md), [Stats Overlay](/docs/special-fx/stats-overlay.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Stats Overlay](/docs/special-fx/stats-overlay.md), [Video Effects](/docs/special-fx/video-effects.md), [Voronoi](/docs/special-fx/voronoi.md), [Truchet](/docs/special-fx/truchet.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Audio Link](/docs/audio-link/audio-link.md), [Global Themes](/docs/modifiers/global-themes.md), [Global Mask](/docs/modifiers/global-masks.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Color & Normals](/color-and-normals/color-and-normals.md), [Color Adjust (Hue Shift)](/color-and-normals/color-adjust.md), [Details](/color-and-normals/details.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Alpha Options](/color-and-normals/alpha-options.md), [Back Face](/color-and-normals/back-face.md), [Normal Correct](/color-and-normals/normal-correct.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Decals](/color-and-normals/decals.md), [RGBA Color Masking](/color-and-normals/rgba-color-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Anisotropics](/shading/anisotropics.md), [Matcaps](/shading/matcap.md), [CubeMap](/shading/cubemap.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Rim Lighting](/shading/rim-lighting.md), [Depth Rim Lighting](/shading/depth-rim-lighting.md), [Subsurface Scattering](/shading/subsurface-scattering.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Reflections & Specular](/shading/reflections-and-specular.md), [Clear Coat](/shading/clear-coat.md), [Environmental Rim](/shading/environmental-rim.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Stylized Reflections](/shading/stylized-reflections.md), [Backlight](/shading/backlight.md), [LTCGI](/shading/ltcgi.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Outlines](/outlines/outlines.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [UV Tile Discard](/special-fx/uv-tile-discard.md), [Proximity Color](/special-fx/proximity-color.md), [Mirror/Camera Visibility](/special-fx/mirror.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Depth Bulge](/special-fx/depth-bulge.md), [Depth FX](/special-fx/depth-fx.md), [Internal Parallax](/special-fx/internal-parallax.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Emissions](/special-fx/emission.md), [Glitter/Sparkle](/special-fx/glitter.md), [Dissolve](/special-fx/dissolve.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Flipbook](/special-fx/flipbook.md), [Pathing](/special-fx/pathing.md), [Stats Overlay](/special-fx/stats-overlay.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Stats Overlay](/special-fx/stats-overlay.md), [Video Effects](/special-fx/video-effects.md), [Voronoi](/special-fx/voronoi.md), [Truchet](/special-fx/truchet.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Audio Link](/audio-link/audio-link.md), [Global Themes](/modifiers/global-themes.md), [Global Mask](/modifiers/global-masks.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [VRC Light Volumes <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://github.com/REDSIM/VRCLightVolumes) Support | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [BlackLight Masking](/docs/modifiers/blacklight-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [BlackLight Masking](/modifiers/blacklight-masking.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Stochastic Sampling, Distortion UV, Panosphere UV, Polar UV | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Parallax Heightmapping](/docs/modifiers/uvs/parallax.md), [Post Processing Animations](/docs/modifiers/post-processing/pp-animations.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Lil Fur](/docs/extended-features/lilfur.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Parallax Heightmapping](/modifiers/uvs/parallax.md), [Post Processing Animations](/modifiers/post-processing/pp-animations.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Lil Fur](/extended-features/lilfur.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Vertex Options |  |  |  |  |  |  |
-| [Basics & Fun](/docs/vertex-options/basics.md), [Glitching](/docs/vertex-options/glitching.md), [LookAt](/docs/vertex-options/look-at.md), [Vertex Colors](/docs/vertex-options/vertex-colors.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Shading Styles](/docs/shading/main.md) |  |  |  |  |  |  |
+| [Basics & Fun](/vertex-options/basics.md), [Glitching](/vertex-options/glitching.md), [LookAt](/vertex-options/look-at.md), [Vertex Colors](/vertex-options/vertex-colors.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Shading Styles](/shading/main.md) |  |  |  |  |  |  |
 | Texture Ramp, Multilayer Math, Wrapped, Skin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ShadeMap, Flat, Realistic, Cloth, SDF | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Rendering Presets](/docs/general/render-preset.md) |  |  |  |  |  |  |
+| [Rendering Presets](/general/render-preset.md) |  |  |  |  |  |  |
 | Opaque, Cutout, TransClipping, Fade, Transparent | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Additive, Soft Additive, Multiplicative, 2x Multiplicative | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Two Pass Transparency | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Grab Pass](/docs/extended-features/grabpass.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Grab Pass](/extended-features/grabpass.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Pro Features** | | | | | | |
-| [Screen Space Ambient Occlusion](/docs/shading/ssao.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Screen Space Ambient Occlusion](/shading/ssao.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Custom Modules | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Geometric Dissolve](/docs/extended-features/geometric-dissolve.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Fur and World Fur](/docs/extended-features/fur.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Shatterwave](/docs/extended-features/shatterwave.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Tessellated](/docs/extended-features/tessellated.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Geometric Dissolve](/extended-features/geometric-dissolve.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Fur and World Fur](/extended-features/fur.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Shatterwave](/extended-features/shatterwave.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Tessellated](/extended-features/tessellated.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Tessellated Geometric | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Particles](/docs/extended-features/particle.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Particles](/extended-features/particle.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Constellation | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Wireframe | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | NameTag | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |

--- a/versioned_docs/version-9.3/extended-features/fur.md
+++ b/versioned_docs/version-9.3/extended-features/fur.md
@@ -96,7 +96,7 @@ Enables options to change the Hue of the fur color using the Animator.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 

--- a/versioned_docs/version-9.3/extended-features/geometric-dissolve.md
+++ b/versioned_docs/version-9.3/extended-features/geometric-dissolve.md
@@ -318,7 +318,7 @@ Shows only the Wireframe.
 Allows an alternative way to use UV Tile Discard with the use of Geometric Dissolve's advanced effects instead.
 
 :::info Refer to UV Tile Documentation
-All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
+All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
 
 Each Slider will control the `Dissolve Alpha` for the described Row and Column.
 :::
@@ -333,7 +333,7 @@ Choice of which UV to use for the Tile Dissolve.
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `-1.0 - 1.0`
 
-This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
+This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
 
 |  | Column 0 | Column 1 | Column 2 | Column 3 |
 | :---: | :---: | :---: | :---: | :---: |

--- a/versioned_docs/version-9.3/extended-features/grabpass.md
+++ b/versioned_docs/version-9.3/extended-features/grabpass.md
@@ -134,7 +134,7 @@ Scaler for the blend amount. The Grab Pass color is blended with the base color 
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) should be used as the Blend Map.
+Select which [Global Mask](/modifiers/global-masks.md) should be used as the Blend Map.
 
 ### Source/Destination Blend
 
@@ -142,4 +142,4 @@ Select which [Global Mask](/docs/modifiers/global-masks.md) should be used as th
 
 Blend factor to use for the source and destination factors, respectively.
 
-For traditional transparent blending, `Source Blend` should be set to `SrcAlpha` and `Destination Blend` should be set to `OneMinusSrcAlpha`. Other factors can be used for other effects. Try some of the combinations listed in [Render Presets](/docs/general/render-preset.md#blending).
+For traditional transparent blending, `Source Blend` should be set to `SrcAlpha` and `Destination Blend` should be set to `OneMinusSrcAlpha`. Other factors can be used for other effects. Try some of the combinations listed in [Render Presets](/general/render-preset.md#blending).

--- a/versioned_docs/version-9.3/extended-features/lilfur.md
+++ b/versioned_docs/version-9.3/extended-features/lilfur.md
@@ -21,7 +21,7 @@ Please keep this in mind when using Lil Fur.
 
 This chooses the rendering mode to use for Lil Fur. Settings will be applied to the module's [Rendering](#rendering) properties.
 
-For reference on the meanings of these modes, see [Rendering Presets](/docs/general/render-preset.md).
+For reference on the meanings of these modes, see [Rendering Presets](/general/render-preset.md).
 
 ## Fur
 
@@ -133,7 +133,7 @@ Sets the Anti Light factor on the Fur's Rim Lighting.
 :::warning Heads Up
 These properties are automatically set based on the [Fur Mode](#fur-mode) set. If you intend to modify these properties below, please do so with care.
 
-Most, if not all properties that are listed here are the same descriptions as notated in [Rendering](/docs/rendering/rendering.md). However, these settings are completely independent of the material's overall Rendering settings.
+Most, if not all properties that are listed here are the same descriptions as notated in [Rendering](/rendering/rendering.md). However, these settings are completely independent of the material's overall Rendering settings.
 :::
 
 ### Cull
@@ -147,25 +147,25 @@ Sets what faces should be culled.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### DstBlend RGB
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### SrcBlend Alpha
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha source on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### DstBlend Alpha
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha destination on the Fur. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### BlendOp RGB
 
@@ -242,7 +242,7 @@ Sets the Alpha to affect the Mask of the Fur.
 ## Stencil
 
 :::warning Heads Up
-Most, if not all properties that are listed here are the same descriptions as notated in [Stencil](/docs/rendering/stencil.md). However, these settings are completely independent of the material's overall Stencil settings.
+Most, if not all properties that are listed here are the same descriptions as notated in [Stencil](/rendering/stencil.md). However, these settings are completely independent of the material's overall Stencil settings.
 :::
 
 ### Stencil Type

--- a/versioned_docs/version-9.3/extended-features/particle.md
+++ b/versioned_docs/version-9.3/extended-features/particle.md
@@ -17,7 +17,7 @@ To use Poiyomi Pro Particle, select the shader version `.poiyomi/Poiyomi Pro Par
 :::tip Works best with Cutout or Transparent Rendering
 Like many Particles, they each spawn with square-shaped planes that contains a texture. Most commonly, those textures have transparent backgrounds.
 
-When using a Texture or Sprite Sheet with a transparent background, change your [Rendering Preset](/docs/general/render-preset.md) to `Cutout` or a preferred transparent preset (if using Alpha transitions) for the best effect.
+When using a Texture or Sprite Sheet with a transparent background, change your [Rendering Preset](/general/render-preset.md) to `Cutout` or a preferred transparent preset (if using Alpha transitions) for the best effect.
 :::
 
 <ReactVideo src='/vid/extended-features/overkillparticles.webm'/>
@@ -83,7 +83,7 @@ Use a Vertex Color Channel from your mesh as the Spawn Mask.
 This should be the main texture you wish to use for the Particle's overall appearance.
 
 :::tip Use a texture with Transparency
-We recommend using a texture that has a transparent background. For best results, use Cutout or a Transparent [Rendering Preset](/docs/general/render-preset.md) on your Material for your Particles to appear correctly.
+We recommend using a texture that has a transparent background. For best results, use Cutout or a Transparent [Rendering Preset](/general/render-preset.md) on your Material for your Particles to appear correctly.
 :::
 
 ### Color
@@ -291,7 +291,7 @@ The bias of how each Frame is treated.
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Gradient Source

--- a/versioned_docs/version-9.3/extended-features/shatterwave.md
+++ b/versioned_docs/version-9.3/extended-features/shatterwave.md
@@ -5,7 +5,7 @@ description: Poiyomi ShatterWave is an advanced special effect that uses the mes
 keywords: [shatterwave, poiyomi, shader]
 ---
 
-ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. This effect is very similar to [Geometric Dissolve](/docs/extended-features/geometric-dissolve.md) with the exception of it being animated in an ocean wave-like effect instead.
+ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. This effect is very similar to [Geometric Dissolve](/extended-features/geometric-dissolve.md) with the exception of it being animated in an ocean wave-like effect instead.
 
 To use Poiyomi ShatterWave, select the shader version `.poiyomi/Poiyomi Pro ShatterWave`. This exposes the ShatterWave category with the following settings shown below.
 
@@ -52,7 +52,7 @@ Creates an Emissive effect on the ShatterWave's color.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Allows you to add the currently set ShatterWave setup to be applied to an existing [Global Mask](/docs/modifiers/global-masks.md) of your choice.
+Allows you to add the currently set ShatterWave setup to be applied to an existing [Global Mask](/modifiers/global-masks.md) of your choice.
 
 ## Show Under Wave
 
@@ -82,7 +82,7 @@ Creates an Emissive effect underneath the ShatterWave's mesh.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Allows you to add the currently set Under Wave setup to be applied to an existing [Global Mask](/docs/modifiers/global-masks.md) of your choice.
+Allows you to add the currently set Under Wave setup to be applied to an existing [Global Mask](/modifiers/global-masks.md) of your choice.
 
 ## Wave Speed X Y Z
 
@@ -117,7 +117,7 @@ Measures how dense the waves are in tiled coordinates.
 Enables Audio Link to manipulate the ShatterWave.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ## Emission Multiplier Band

--- a/versioned_docs/version-9.3/extended-features/two-pass.md
+++ b/versioned_docs/version-9.3/extended-features/two-pass.md
@@ -7,7 +7,7 @@ keywords: [two pass, 2nd pass, two, pass, poiyomi, shader]
 
 The Two Pass version does two rendering passes on the shader with the inside of the Mesh rendered first and the outside second (Cull Front > Cull Back). This special version should only be used when creating Meshes that need to have double the rendering pass, especially with Transparency.
 
-To use the Two Pass shader, select the shader version `.poiyomi/Poiyomi Toon Two Pass`. When this shader is selected, a `2nd Pass` category will be exposed on the UI below Color & Normals with the properties shown below. Additionally, three additional sections will be exposed under [Rendering](/docs/rendering/rendering.md) and will appear as `2nd Pass Rendering`, `2nd Pass Blending`, and `2nd Pass Stencil`.
+To use the Two Pass shader, select the shader version `.poiyomi/Poiyomi Toon Two Pass`. When this shader is selected, a `2nd Pass` category will be exposed on the UI below Color & Normals with the properties shown below. Additionally, three additional sections will be exposed under [Rendering](/rendering/rendering.md) and will appear as `2nd Pass Rendering`, `2nd Pass Blending`, and `2nd Pass Stencil`.
 
 :::warning Performance Warning
 Because the Two Pass shader renders everything twice, it can have a slight performance impact. Use it wisely!
@@ -19,7 +19,7 @@ Because the Two Pass shader renders everything twice, it can have a slight perfo
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**
 
-Sets the Rendering Preset for the 2nd Pass. Refer to the [Rendering Presets](/docs/general/render-preset.md) for more information on what they do.
+Sets the Rendering Preset for the 2nd Pass. Refer to the [Rendering Presets](/general/render-preset.md) for more information on what they do.
 
 ### First Pass Mask
 
@@ -43,7 +43,7 @@ If enabled, the Second Pass will override the Main Color of the Material.
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `0.0 - 1.0`
 
-Just like it was described in [Color & Normals](/docs/color-and-normals/color-and-normals.md#alpha-cutoff), the **Alpha Cutoff** value sets the alpha value for the 2nd Pass at which to [clip](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-clip) a pixel. If the alpha value of a pixel is below this value, the pixel is [discarded](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-discard).
+Just like it was described in [Color & Normals](/color-and-normals/color-and-normals.md#alpha-cutoff), the **Alpha Cutoff** value sets the alpha value for the 2nd Pass at which to [clip](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-clip) a pixel. If the alpha value of a pixel is below this value, the pixel is [discarded](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-discard).
 
 ### Invert Alpha Cutoff
 
@@ -55,7 +55,7 @@ This inverts the Alpha Cutoff.
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Just like it was described in [Alpha Options](/docs/color-and-normals/alpha-options.md#force-opaque), this option forces the 2nd Pass to have an alpha value of 1. Generally, this will result in any transparency on the 2nd Pass being disabled.
+Just like it was described in [Alpha Options](/color-and-normals/alpha-options.md#force-opaque), this option forces the 2nd Pass to have an alpha value of 1. Generally, this will result in any transparency on the 2nd Pass being disabled.
 
 ### Alpha Power
 

--- a/versioned_docs/version-9.3/general/alt-versions.md
+++ b/versioned_docs/version-9.3/general/alt-versions.md
@@ -31,7 +31,7 @@ We recommend only using this Shader if you are using the Worlds SDK.
 
 - `.poiyomi/Poiyomi Toon Two Pass`
 
-The Two Pass version renders the inside of the Mesh first, rather than the outside (Cull Front > Cull Back). See [Two Pass](/docs/extended-features/two-pass.md) for more info.
+The Two Pass version renders the inside of the Mesh first, rather than the outside (Cull Front > Cull Back). See [Two Pass](/extended-features/two-pass.md) for more info.
 
 Because the Two Pass shader renders everything twice, it can have a slight performance impact.
 
@@ -47,7 +47,7 @@ As Outline Early renders the Outline twice, it can have a slight performance imp
 
 - `.poiyomi/Poiyomi Toon Grab Pass`
 
-The Grab Pass Shader is used for specialized effects that require taking a screenshot every frame in order for it to render. See [Grab Pass](/docs/extended-features/grabpass.md) for more info.
+The Grab Pass Shader is used for specialized effects that require taking a screenshot every frame in order for it to render. See [Grab Pass](/extended-features/grabpass.md) for more info.
 
 Because this shader version uses a Grab Pass, it has the <u>strongest performance impact</u> as it has to take a screenshot every frame to render. If you wish to use this feature, use it judiciously!
 
@@ -55,13 +55,13 @@ Because this shader version uses a Grab Pass, it has the <u>strongest performanc
 
 - `.poiyomi/Poiyomi Pro Geometric Dissolve`
 
-Poiyomi Pro Geometric Dissolve is an advanced version in Poiyomi Pro that expands beyond the features of what a typical Dissolve can offer. It uses the 3D Mesh to manipulate the vertices, creating an advanced 3D Dissolve animation. See [Geometric Dissolve](/docs/extended-features/geometric-dissolve.md) for more info.
+Poiyomi Pro Geometric Dissolve is an advanced version in Poiyomi Pro that expands beyond the features of what a typical Dissolve can offer. It uses the 3D Mesh to manipulate the vertices, creating an advanced 3D Dissolve animation. See [Geometric Dissolve](/extended-features/geometric-dissolve.md) for more info.
 
 ## Fur
 
 - `.poiyomi/Poiyomi Pro Fur`
 
-Poiyomi Pro Fur is a system in Poiyomi Pro that uses a height-based technique to enable simulation of fabrics and hairs. It can look similar to how fur is simulated in animated films but with some differences. See [Fur](/docs/extended-features/fur.md) for more info.
+Poiyomi Pro Fur is a system in Poiyomi Pro that uses a height-based technique to enable simulation of fabrics and hairs. It can look similar to how fur is simulated in animated films but with some differences. See [Fur](/extended-features/fur.md) for more info.
 
 Fur simulation is a very expensive feature, as it must render every frame in order to simulate the effect. As such, this will cause a huge performance impact when used.
 
@@ -69,13 +69,13 @@ Fur simulation is a very expensive feature, as it must render every frame in ord
 
 - `.poiyomi/Poiyomi Pro ShatterWave`
 
-Poiyomi Pro ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. It functions similar to Geometric Dissolve, but does it in a wavy pattern instead. See [ShatterWave](/docs/extended-features/shatterwave.md) for more info.
+Poiyomi Pro ShatterWave is an advanced special effect that uses the mesh's vertices to create a wavy effect across the mesh in variation. It functions similar to Geometric Dissolve, but does it in a wavy pattern instead. See [ShatterWave](/extended-features/shatterwave.md) for more info.
 
 ## Tessellated
 
 - `.poiyomi/Poiyomi Pro Tessellated`
 
-The Tessellated shader includes a shading process that subdivides triangles into a more realistic structure for certain realistic effects. See [Tessellated](/docs/extended-features/tessellated.md) for more info.
+The Tessellated shader includes a shading process that subdivides triangles into a more realistic structure for certain realistic effects. See [Tessellated](/extended-features/tessellated.md) for more info.
 
 Tessellated shaders are extremely expensive and will greatly hinder your computer's performance, even on the most powerful hardware out there. Please exercise caution if using it.
 
@@ -83,7 +83,7 @@ Tessellated shaders are extremely expensive and will greatly hinder your compute
 
 - `.poiyomi/Poiyomi Pro Particle`
 
-Poiyomi Pro Fur is a Geometric Particle shader that uses the 3D mesh to spawn each Particle from, similar to a Particle System in Unity. See [Particle](/docs/extended-features/particle.md) for more info.
+Poiyomi Pro Fur is a Geometric Particle shader that uses the 3D mesh to spawn each Particle from, similar to a Particle System in Unity. See [Particle](/extended-features/particle.md) for more info.
 
 Just like Geometric Dissolve, it can have a significant performance impact.
 
@@ -92,6 +92,6 @@ Just like Geometric Dissolve, it can have a significant performance impact.
 - `.poiyomi/Poiyomi Toon + Lil Fur`
 - `.poiyomi/Poiyomi Toon + Lil Fur Two Pass`
 
-Similar to Poiyomi Fur, but instead uses the same simulation technique on LilToon's Fur Shader. See [Lil Fur](/docs/extended-features/lilfur.md) for more details.
+Similar to Poiyomi Fur, but instead uses the same simulation technique on LilToon's Fur Shader. See [Lil Fur](/extended-features/lilfur.md) for more details.
 
 The Lil Fur shader uses a separate pass for the fur shading, meaning it does not stack with other Poiyomi features. However, this shader may have a performance impact.

--- a/versioned_docs/version-9.3/general/faq.md
+++ b/versioned_docs/version-9.3/general/faq.md
@@ -15,7 +15,7 @@ This is a list of Frequently Asked Questions regarding Poiyomi Shaders. If you a
 
 ### What is the Poiyomi Shaders Terms of Service?
 
-A dedicated page is available which shows important information about the usage of the Shader. Please see [Terms of Service](/docs/terms-of-service/terms-of-service.md) for more details.
+A dedicated page is available which shows important information about the usage of the Shader. Please see [Terms of Service](/terms-of-service/terms-of-service.md) for more details.
 
 ### I'm trying to import a version that's in-between the versions the Unity Package specifies. How do I install them?
 
@@ -59,17 +59,17 @@ If this function fails to work and you get that message, ensure there are no scr
 
 ### How do I upgrade Poiyomi Shaders to a newer version?
 
-To upgrade the shader, refer to the instructions found in [Download & Install](/docs/download/download.md) for the Method you used when you first installed the Shader.
+To upgrade the shader, refer to the instructions found in [Download & Install](/download/download.md) for the Method you used when you first installed the Shader.
 
 Sometimes when updating your locked materials may get stuck in the locked state. This happens because the name of the shader changed. Avoid this by unlocking materials before updating. To Fix this, reselect the correct Poiyomi shader for the broken materials.
 
 :::warning
-If you are jumping from much older versions (7.3 or older) to the latest, [please refer to this documentation to learn how to account for these major changes](/docs/general/upgrade/upgrade.md).
+If you are jumping from much older versions (7.3 or older) to the latest, [please refer to this documentation to learn how to account for these major changes](/general/upgrade/upgrade.md).
 :::
 
 ### I'm trying to animate a property in the Material which kind of works, but it STOPS working when the Material gets Locked. What can I do?
 
-You need to mark properties that you are animating by `Right-Clicking` on them and selecting `Animated` or `Renamed`, which are specific tags that ensure the property remains accessible when the Shader is locked. For more information, see the Documentation page [Locking and Animation](/docs/general/locking.md#marking-properties-for-animation) for further reading.
+You need to mark properties that you are animating by `Right-Clicking` on them and selecting `Animated` or `Renamed`, which are specific tags that ensure the property remains accessible when the Shader is locked. For more information, see the Documentation page [Locking and Animation](/general/locking.md#marking-properties-for-animation) for further reading.
 
 Keep in mind that properties marked as `Renamed` will only work when the Material is Locked. **Make sure you Lock the Material prior to recording your animations!**
 
@@ -79,9 +79,9 @@ Keep in mind that properties marked as `Renamed` will only work when the Materia
 
 ### Where do AO Maps go in Poiyomi Shaders?
 
-Place AO (Ambient Occlusion) Maps in the [AO Maps](/docs/shading/light-data.md#ao-maps) Texture Slot, located in `Shading -> Light Data`.
+Place AO (Ambient Occlusion) Maps in the [AO Maps](/shading/light-data.md#ao-maps) Texture Slot, located in `Shading -> Light Data`.
 
-It is recommended to use a [Lighting Type](/docs/shading/main.md#lighting-type) that supports AO Maps. Only Realistic-based Lighting Types will allow AO maps to appear correctly.
+It is recommended to use a [Lighting Type](/shading/main.md#lighting-type) that supports AO Maps. Only Realistic-based Lighting Types will allow AO maps to appear correctly.
 
 ### Where does Height Maps go in Poiyomi Shaders?
 
@@ -89,7 +89,7 @@ Height maps are generally used to change the shape of the surface of a material.
 
 If you have a height map but not a normal map, you can convert it in Unity by setting the texture to a Normal map and selecting `Convert from Grayscale`.
 
-If you need the displacement, you can use it with [Parallax Heightmapping](/docs/modifiers/uvs/parallax.md), which creates a displacement-like effect. You can also use a shader that tessellates, which will add geometry to create the height detail. Please be aware that this is not an optimized method and may have a performance impact!
+If you need the displacement, you can use it with [Parallax Heightmapping](/modifiers/uvs/parallax.md), which creates a displacement-like effect. You can also use a shader that tessellates, which will add geometry to create the height detail. Please be aware that this is not an optimized method and may have a performance impact!
 
 ### What is the difference between Roughness vs. Smoothness Maps?
 
@@ -97,19 +97,19 @@ Roughness and Smoothness have the same information, just flipped!
 
 You can invert it in an image editor or use the invert checkboxes.
 
-**For v8+**, Roughness goes in [Reflections & Specular](/docs/shading/reflections-and-specular.md).
+**For v8+**, Roughness goes in [Reflections & Specular](/shading/reflections-and-specular.md).
 
-Open Packed Maps by clicking on the triangle and place the Roughness in the [G Smoothness Map](/docs/shading/reflections-and-specular.md#packed-maps) slot. It is important that you checkmark `Invert` so that it matches the Unity PBR Shading Pipeline. [Refer to the Documentation Page](/docs/shading/reflections-and-specular.md#packed-maps) for more information.
+Open Packed Maps by clicking on the triangle and place the Roughness in the [G Smoothness Map](/shading/reflections-and-specular.md#packed-maps) slot. It is important that you checkmark `Invert` so that it matches the Unity PBR Shading Pipeline. [Refer to the Documentation Page](/shading/reflections-and-specular.md#packed-maps) for more information.
 
 ### How do I test Audio Link in Poiyomi Shaders?
 
-We have dedicated instructions in our Audio Link feature Documentation on how to test Audio Link in Unity. [Please take a look at it (Click Here)](/docs/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders)
+We have dedicated instructions in our Audio Link feature Documentation on how to test Audio Link in Unity. [Please take a look at it (Click Here)](/audio-link/audio-link.md#how-to-test-audio-link-using-poiyomi-shaders)
 
 ### Why isn't Audio Link playing music in the Scene?
 
 The `AudioLinkAvatar` prefab in the scene uses the yt-dlp plugin from the VRChat installation files. However, YouTube has continuously made destructive changes to the audio/video format, which breaks it's functionality.
 
-Instead, you will need to manually specify a separate `yt-dlp.exe` to use instead to play audio. [Read the instructions carefully on our Docs (Click Here)](/docs/audio-link/audio-link.md#using-a-custom-ytdl-location)
+Instead, you will need to manually specify a separate `yt-dlp.exe` to use instead to play audio. [Read the instructions carefully on our Docs (Click Here)](/audio-link/audio-link.md#using-a-custom-ytdl-location)
 
 ### I am using a feature that is supposed to animate, but it doesn't show it's animating. Why is that?
 
@@ -147,18 +147,18 @@ Due to Unity Editor limitations, you cannot do this as it can cause problems at 
 
 While it is not possible to animate texture slots, Poiyomi Shaders has features that can make up for this. Try out using these modules:
 
-- [Decals](/docs/color-and-normals/decals.md), a decorative feature. You can animate the `Alpha` slider to control the visibility of the Texture using a Decal.
-- [Dissolve](/docs/special-fx/dissolve.md), a Special FX feature that can gradually introduce a different Texture through a visual transition.
-- [Geometric Dissove](/docs/extended-features/geometric-dissolve.md). Like Dissolve, but uses your Mesh's Geometry to transition to a different Texture.
-- [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), to animate offsets when needed.
+- [Decals](/color-and-normals/decals.md), a decorative feature. You can animate the `Alpha` slider to control the visibility of the Texture using a Decal.
+- [Dissolve](/special-fx/dissolve.md), a Special FX feature that can gradually introduce a different Texture through a visual transition.
+- [Geometric Dissove](/extended-features/geometric-dissolve.md). Like Dissolve, but uses your Mesh's Geometry to transition to a different Texture.
+- [UV Tile Discard](/special-fx/uv-tile-discard.md), to animate offsets when needed.
 
 ### What happened to "Basic Emission" in the shader?
 
 Basic Emission was removed in version 8.0 and newer because it was often used incorrectly.
 
-If you're wanting to make the model not too dark, it's generally better to use [Min Brightness](/docs/shading/light-data.md#min-brightness) located in Light Data for that purpose, as it won't over-brighten the avatar in various situations.
+If you're wanting to make the model not too dark, it's generally better to use [Min Brightness](/shading/light-data.md#min-brightness) located in Light Data for that purpose, as it won't over-brighten the avatar in various situations.
 
-If you REALLY need to add what used to be called "Basic Emission," you can use an [Emission](/docs/special-fx/emission.md) slot with `Use Base Colors` enabled and set a desired intensity.
+If you REALLY need to add what used to be called "Basic Emission," you can use an [Emission](/special-fx/emission.md) slot with `Use Base Colors` enabled and set a desired intensity.
 
 ### Why use OKLab for Hue Shift instead of HSV?
 
@@ -178,7 +178,7 @@ This can happen when you have a large number of materials using Poiyomi while un
 
 To circumvent this issue, you can lock materials when not in use, as that will generate unique shaders for each material.
 
-More information documented [here](/docs/general/textures-64-texture-slot-crash.md).
+More information documented [here](/general/textures-64-texture-slot-crash.md).
 
 ### Why does lighting change randomly while moving in a World?
 

--- a/versioned_docs/version-9.3/general/locking.md
+++ b/versioned_docs/version-9.3/general/locking.md
@@ -76,7 +76,7 @@ The unique suffix assigned for Properties marked as `RA` will depend on the name
 | **"Suit Jacket"** | Audio Link -> Anim Toggle | `_AudioLinkAnimToggle` | `_Suit_Jacket` | `_AudioLinkAnimToggle_Suit_Jacket` | 
 | **"Outfit Shirt"** | Color Adjust -> Hue Shift -> Hue Shift | `_MainHueShift` | `_Outfit_Shirt` | `_MainHueShift_Outfit_Shirt` |
 
-If you wish to enforce a specific custom renaming scheme for `RA` properties, enable [Allow custom renaming for locking](/docs/thryeditor/settings.md#allow-custom-renaming-for-locking) under Thry Editor settings. This exposes a dedicated field on the top of the material inspector, where you can type in a custom suffix for the material to use instead.
+If you wish to enforce a specific custom renaming scheme for `RA` properties, enable [Allow custom renaming for locking](/thryeditor/settings.md#allow-custom-renaming-for-locking) under Thry Editor settings. This exposes a dedicated field on the top of the material inspector, where you can type in a custom suffix for the material to use instead.
 
 ## Copying Properties for Animation
 
@@ -128,18 +128,18 @@ The following table provides a list of features that will be animated on all mat
 
 This behavior is not a bug, it's behavior defined by Unity, beyond the control of the shader author (given the need to name these properties specifically for fallback shaders to work correctly).
 
-| Property Name | Can be Renamed? | Property |
-| :--- | :--- | :--- |
-| `_Color`                  | ✅ | [Main Color](/docs/color-and-normals/color-and-normals.md#color--alpha) |
-| `_MainTex_ST`             | ❌ | [Main Texture Tiling/Offset](/docs/color-and-normals/color-and-normals.md#texture) |
-| `_BumpMap_ST`             | ❌ | [Normal Map Tiling/Offset](/docs/color-and-normals/color-and-normals.md#normal-map) |
-| `_BumpScale`              | ✅ | [Normal Map Intensity](/docs/color-and-normals/color-and-normals.md#normal-map) |
-| `_Cutoff`                 | ✅ | [Alpha Cutoff](/docs/color-and-normals/color-and-normals.md#alpha-cutoff) |
-| `_DetailMask_ST`          | ❌ | [Detail Mask Tiling/Offset](/docs/color-and-normals/details.md#detail-mask) |
-| `_DetailNormalMap_ST`     | ❌ | [Detail Mask Tiling/Offset](/docs/color-and-normals/details.md#detail-normal) |
-| `_DetailNormalMapScale`   | ✅ | [Detail Mask Tiling/Offset](/docs/color-and-normals/details.md#normal-intensity) |
-| `_EmissionColor`          | ✅ | [Emission 0 Color](/docs/special-fx/emission.md#emission-color) |
-| `_EmissionMap_ST`         | ❌ | [Emission 0 Map Tiling/Offset](/docs/special-fx/emission.md#emission-map) |
+| Property Name | Can be Renamed? | Property                                                                           |
+| :--- | :--- |:-----------------------------------------------------------------------------------|
+| `_Color`                  | ✅ | [Main Color](/color-and-normals/color-and-normals.md#color--alpha)                 |
+| `_MainTex_ST`             | ❌ | [Main Texture Tiling/Offset](/color-and-normals/color-and-normals.md#main-texture) |
+| `_BumpMap_ST`             | ❌ | [Normal Map Tiling/Offset](/color-and-normals/color-and-normals.md#normal-map)     |
+| `_BumpScale`              | ✅ | [Normal Map Intensity](/color-and-normals/color-and-normals.md#normal-map)         |
+| `_Cutoff`                 | ✅ | [Alpha Cutoff](/color-and-normals/color-and-normals.md#alpha-cutoff)               |
+| `_DetailMask_ST`          | ❌ | [Detail Mask Tiling/Offset](/color-and-normals/details.md#detail-mask)             |
+| `_DetailNormalMap_ST`     | ❌ | [Detail Mask Tiling/Offset](/color-and-normals/details.md#detail-normal)           |
+| `_DetailNormalMapScale`   | ✅ | [Detail Mask Tiling/Offset](/color-and-normals/details.md#normal-intensity)        |
+| `_EmissionColor`          | ✅ | [Emission 0 Color](/special-fx/emission.md#emission-color)                         |
+| `_EmissionMap_ST`         | ❌ | [Emission 0 Map Tiling/Offset](/special-fx/emission.md#emission-map)               |
 
 ## Non-Animatable Properties
 
@@ -154,9 +154,9 @@ To adjust these properties at runtime, you'll need to create different materials
 These section checkboxes signal the shader to add and remove code. **Thus, they cannot be animated at runtime whatsoever**.
 
 If you want to toggle the effect of a section, use a property that controls the overall effect. For example,
-- To disable [Color Adjust](/docs/color-and-normals/color-adjust.md), you could animate the settings to their default values.
-- To disable a [Decal](/docs/color-and-normals/decals.md), animate its `Alpha` value to `0`. If the Decal has Emissions, also animate its `Emission Strength` value to `0`.
-- To disable [Audio Link](/docs/audio-link/audio-link.md), animate the `Anim Toggle` to be *un-checked*.
+- To disable [Color Adjust](/color-and-normals/color-adjust.md), you could animate the settings to their default values.
+- To disable a [Decal](/color-and-normals/decals.md), animate its `Alpha` value to `0`. If the Decal has Emissions, also animate its `Emission Strength` value to `0`.
+- To disable [Audio Link](/audio-link/audio-link.md), animate the `Anim Toggle` to be *un-checked*.
 
 For other sections, make sure to refer to the appropriate documentation pages on them so that you can know which properties you should animate as a toggle.
 
@@ -205,7 +205,7 @@ These options relate to low-level directives and settings that change how the gr
 
 The locking feature uses an optimization procedure developed by [Kaj](https://github.com/DarthShader/Kaj-Unity-Shaders). When the shader is locked in, a unique version is generated that removes unused code, defines fixed values for non-animated shader properties, and defined unused texture slots to be fixed values.
 
-This significantly improves performance, helps mitigate the [64 texture slot crash](/docs/general/textures-64-texture-slot-crash.md) sometimes seen when many complex materials with lots of modules enabled are present in a scene.
+This significantly improves performance, helps mitigate the [64 texture slot crash](/general/textures-64-texture-slot-crash.md) sometimes seen when many complex materials with lots of modules enabled are present in a scene.
 
 [^1]: For a more complete list, see the [List of some "Illegal Property Renames"](https://github.com/Thryrallo/ThryEditor/blob/master/Editor/ShaderOptimizer.cs#L227)
 

--- a/versioned_docs/version-9.3/general/render-preset.md
+++ b/versioned_docs/version-9.3/general/render-preset.md
@@ -7,7 +7,7 @@ keywords: [render, rendering, preset, opaque, cutout, transparent, transclipping
 
 At the top of the shader, there is a dropdown that may be labeled with something like `Opaque`, `Cutout`, `Transparent`, or something similar. It's located on the bottom-right from the Material Lock/Unlock button.
 
-When you click on this, the dropdown will show the options that are documented on this page. The option you select will automatically configure your [Rendering](/docs/rendering/rendering.md) settings to ensure they appear as intended.
+When you click on this, the dropdown will show the options that are documented on this page. The option you select will automatically configure your [Rendering](/rendering/rendering.md) settings to ensure they appear as intended.
 
 <a target="_blank" href="/img/general/RenderingPresets-new.png">
 <img src="/img/general/RenderingPresets-new.png" alt="Rendering Presets Dropdown Menu" width="700px"/>
@@ -33,8 +33,8 @@ Similar to Opaque, but allows a yes/no for whether a pixel should be rendered. T
 
 By default, cutout is binary: it either renders or it doesn't. You can use certain options to improve partially transparent areas and edges:
 
-- [Dithering](/docs/color-and-normals/alpha-options.md#dithering) uses a technique that introduces noise in order to provide a perceptually smoother transition between two sharp differences in alpha.
-- [Alpha to Coverage](/docs/color-and-normals/alpha-options.md#alpha-to-coverage) uses partial transparency values to provide variable transparency levels when the viewer is using Multi-Sampled Anti-Aliasing (MSAA). The number of transparency levels is equal to the MSAA level (x2, x4, x8, etc). VRChat allows users to select the number of MSAA levels they want to use, so it's best to make your material still look good with no MSAA.
+- [Dithering](/color-and-normals/alpha-options.md#dithering) uses a technique that introduces noise in order to provide a perceptually smoother transition between two sharp differences in alpha.
+- [Alpha to Coverage](/color-and-normals/alpha-options.md#alpha-to-coverage) uses partial transparency values to provide variable transparency levels when the viewer is using Multi-Sampled Anti-Aliasing (MSAA). The number of transparency levels is equal to the MSAA level (x2, x4, x8, etc). VRChat allows users to select the number of MSAA levels they want to use, so it's best to make your material still look good with no MSAA.
 
 :::tip
 You can enable MSAA in your Unity project by going to **Edit** > **Project Settings** > **Quality** and finding the *Anti Aliasing* options, and setting them to *MSAA 4x*.
@@ -113,7 +113,7 @@ The multiplicative preset will always either keep or darken the background color
 
 ### Options
 
-Render Presets Set a bunch of options for how a material should render. They are all set to the default values, but if you know what you're doing, you can adjust them in the [Rendering Settings](/docs/rendering/rendering.md) section.
+Render Presets Set a bunch of options for how a material should render. They are all set to the default values, but if you know what you're doing, you can adjust them in the [Rendering Settings](/rendering/rendering.md) section.
 
 The options that are set by default by rendering presets are:
 

--- a/versioned_docs/version-9.3/general/substance-painter.md
+++ b/versioned_docs/version-9.3/general/substance-painter.md
@@ -41,12 +41,12 @@ Alternatively, place these presets in your exports folder. For most people, this
 
 Textures have a specific prefix when exported: `t_$textureSet_`. `t` indicates it's a texture (and groups textures together when sorted), `$textureSet` which the name of the Material set set being used. At the end of the filename is the type of texture, which will be one of the following:
 
-- `BaseColor`: Place in the [`Main Texture`](/docs/color-and-normals/color-and-normals.md#texture) slot in [Color & Normals](/docs/color-and-normals/color-and-normals.md).
-- `NormalMap`: Place in the [`Normal Map`](/docs/color-and-normals/color-and-normals.md#normal-map) texture slot in [Color & Normals](/docs/color-and-normals/color-and-normals.md). Make sure to mark it as a normal map in the texture import settings.
-- `AmbientOcclusion`: Place in the [`AO`](docs/shading/light-data.md#ao-maps) texture slot in [Light Data](/docs/shading/light-data.md). Make sure to **uncheck sRGB** in the texture import settings.
-- `MetallicSmoothnessMaps`: Place in the [`Packed Maps`](/docs/shading/reflections-and-specular.md#packed-maps) texture slot in [Reflections & Specular](/docs/shading/reflections-and-specular.md). Make sure to **uncheck sRGB** in the texture import settings, and that all of your sliders are set to 1.0, which uses the map's value. Note that this uses `User0` and `User1` channels in Substance Painter for the Reflection and Specular masks respectively, which can be hand-authored to control the amount of reflection and specular.
-- `EmissionMap`: Place in the [`Emission Map`](/docs/special-fx/emission.md#emission-map) texture slot in [`Emission`](/docs/special-fx/emission.md).
-- `GlobalMask`: Place in one of the Global Mask texture slots in [`Global Mask`](/docs/modifiers/global-masks.md). Make sure to **uncheck sRGB** in the texture import settings. Note that this uses the custom **User channels** in Substance for your Masks. This Template is programmed to use `User10` for the `R` channel, `User11` for the `G` channel, `User12` for the `B` channel, and `User13` for the `A` channel.
+- `BaseColor`: Place in the [`Main Texture`](/color-and-normals/color-and-normals.md#main-texture) slot in [Color & Normals](/color-and-normals/color-and-normals.md).
+- `NormalMap`: Place in the [`Normal Map`](/color-and-normals/color-and-normals.md#normal-map) texture slot in [Color & Normals](/color-and-normals/color-and-normals.md). Make sure to mark it as a normal map in the texture import settings.
+- `AmbientOcclusion`: Place in the [`AO`](/shading/light-data.md#ao-maps) texture slot in [Light Data](/shading/light-data.md). Make sure to **uncheck sRGB** in the texture import settings.
+- `MetallicSmoothnessMaps`: Place in the [`Packed Maps`](/shading/reflections-and-specular.md#packed-maps) texture slot in [Reflections & Specular](/shading/reflections-and-specular.md). Make sure to **uncheck sRGB** in the texture import settings, and that all of your sliders are set to 1.0, which uses the map's value. Note that this uses `User0` and `User1` channels in Substance Painter for the Reflection and Specular masks respectively, which can be hand-authored to control the amount of reflection and specular.
+- `EmissionMap`: Place in the [`Emission Map`](/special-fx/emission.md#emission-map) texture slot in [`Emission`](/special-fx/emission.md).
+- `GlobalMask`: Place in one of the Global Mask texture slots in [`Global Mask`](/modifiers/global-masks.md). Make sure to **uncheck sRGB** in the texture import settings. Note that this uses the custom **User channels** in Substance for your Masks. This Template is programmed to use `User10` for the `R` channel, `User11` for the `G` channel, `User12` for the `B` channel, and `User13` for the `A` channel.
 
 <a target="_blank" href="/img/general/substance_texturelocations.png">
 <img src="/img/general/substance_texturelocations.png" alt="V8 Export Texture Locations"/>
@@ -56,11 +56,11 @@ Textures have a specific prefix when exported: `t_$textureSet_`. `t` indicates i
 
 ### Usage Notes
 
-PBR textures look best when paired with realistic lighting. To take best advantage of this, good [Shading](docs/shading/main.md) settings are recommended. Some good starting points include:
+PBR textures look best when paired with realistic lighting. To take best advantage of this, good [Shading](/shading/main.md) settings are recommended. Some good starting points include:
 
-- [Realistic](/docs/shading/main.md#realistic) shading
-- [Multilayer Math](/docs/shading/main.md#multilayer-math) shading, using only the first layer with a Border between `0.4` and `0.7` and a Blur of `0.4-0.6`
-- [Wrapped](/docs/shading/main.md#wrapped) shading with a wrap of around `1.0` and a normalization of around `0.5`
+- [Realistic](/shading/main.md#realistic) shading
+- [Multilayer Math](/shading/main.md#multilayer-math) shading, using only the first layer with a Border between `0.4` and `0.7` and a Blur of `0.4-0.6`
+- [Wrapped](/shading/main.md#wrapped) shading with a wrap of around `1.0` and a normalization of around `0.5`
 
 Matcaps are not recommended, as they don't respond to the lighting environment the way metallics and specular do.
 

--- a/versioned_docs/version-9.3/general/textures-and-colors.md
+++ b/versioned_docs/version-9.3/general/textures-and-colors.md
@@ -127,7 +127,7 @@ If you are an Avatar Creator, consider leaving this OFF in your Packages.
 
 This setting determines the maximum resolution of the texture after Unity compresses it. Texture resolution is the biggest driver of VRAM (Texture Memory) consumption, and it's important to keep your textures as low resolution as they can be while maintaining acceptable visual quality.
 
-4096px and 8192px square textures, in particular, **use large amounts of VRAM**. Where possible, make your textures smaller, and use features like [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md), alternate UV maps, [Decals](/docs/color-and-normals/decals.md), etc., to reduce the need for large, high resolution textures. Using those features can both help improve performance and cut down on VRAM consumption. Your friends will thank you.
+4096px and 8192px square textures, in particular, **use large amounts of VRAM**. Where possible, make your textures smaller, and use features like [RGBA Color Masking](/color-and-normals/rgba-color-masking.md), alternate UV maps, [Decals](/color-and-normals/decals.md), etc., to reduce the need for large, high resolution textures. Using those features can both help improve performance and cut down on VRAM consumption. Your friends will thank you.
 
 :::info VRChat Avatar Size Limits
 Make sure to keep the Max Size of your textures <u>as low as you can</u>, as it will greatly contribute to the final **Download Size** and **Uncompressed Size** of your Avatar. Failure to take this into account may prevent VRChat from even loading your Avatar at all, as it is subject to server-side scanning!
@@ -177,7 +177,7 @@ This option has a caveat. For most textures, the wrap mode defined for the *Main
 
 Most colors in the shader are standard RGBA colors. This means they are stored as four floating point values, with each value ranging from 0 to 1.
 
-Most color pickers have the option to draw from a [Global Theme](/docs/modifiers/global-themes.md), or from a world's Audio Link theme colors. This can be used to create an easy-to-change color palette for your avatar.
+Most color pickers have the option to draw from a [Global Theme](/modifiers/global-themes.md), or from a world's Audio Link theme colors. This can be used to create an easy-to-change color palette for your avatar.
 
 ### HDR Colors
 
@@ -187,13 +187,13 @@ In the Unity Standard Shader, the HDR Color `Intensity` slider serves as the Emi
 
 ### Alpha
 
-The Alpha channel is used to store opacity. It is a floating point value from 0 to 1. Generally, this is used to determine how much an effect or a part of an effect. For example, in [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md), the Alpha channel is used to determine how much of a channel's texture should be used.
+The Alpha channel is used to store opacity. It is a floating point value from 0 to 1. Generally, this is used to determine how much an effect or a part of an effect. For example, in [RGBA Color Masking](/color-and-normals/rgba-color-masking.md), the Alpha channel is used to determine how much of a channel's texture should be used.
 
 One notable exception is the base color, where the Alpha channel is used to determine the amount of opacity for the material.
 
 ### Vertex Colors
 
-[Vertex Colors](/docs/vertex-options/vertex-colors.md) are colors stored on each vertex of a mesh. They can be used to color the mesh, or to store data about the mesh, like each vertex's position, or smoothed vertex normals, both of which can be baked into the mesh using the `Poi -> Vertex Color Baker` tool.
+[Vertex Colors](/vertex-options/vertex-colors.md) are colors stored on each vertex of a mesh. They can be used to color the mesh, or to store data about the mesh, like each vertex's position, or smoothed vertex normals, both of which can be baked into the mesh using the `Poi -> Vertex Color Baker` tool.
 
 ### Color Blending/Tinting
 

--- a/versioned_docs/version-9.3/general/translation.md
+++ b/versioned_docs/version-9.3/general/translation.md
@@ -11,10 +11,10 @@ In Poiyomi Shaders, there are some properties that will completely differ from U
 
 When switching from the Standard shader to Poiyomi, most if not all properties will be carried over with a few exceptions. Please read below to see what will NOT be carried over:
 
-- **Metallic Smoothness**: Properties and Textures such as `_Metallic`, `_Glossiness`, and `MetalGlossMap`, will not be carried over as we use a different workflow as defined by Mochie. When switching over, you must adjust the workflow for [Reflections & Specular](/docs/shading/reflections-and-specular.md) in Poiyomi Shaders. See the documentation page linked in this paragraph to learn more.
-- **Occlusion**: This Texture Slot will not be carried over. However, you should be able to use it under the [AO Maps](/docs/shading/light-data.md) slot in Light Data without a problem. Do keep in mind that AO Maps will only work best with Realistic-based shading.
-- **Detail Maps**: This texture slot will not be carried over as we use a far more advanced setup in both [Details](/docs/color-and-normals/details.md) and [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md).
-- **Detail Albedo x2**: This texture slot will not be carried over as we use a more advanced approach in [Details](/docs/color-and-normals/details.md) feature.
+- **Metallic Smoothness**: Properties and Textures such as `_Metallic`, `_Glossiness`, and `MetalGlossMap`, will not be carried over as we use a different workflow as defined by Mochie. When switching over, you must adjust the workflow for [Reflections & Specular](/shading/reflections-and-specular.md) in Poiyomi Shaders. See the documentation page linked in this paragraph to learn more.
+- **Occlusion**: This Texture Slot will not be carried over. However, you should be able to use it under the [AO Maps](/shading/light-data.md) slot in Light Data without a problem. Do keep in mind that AO Maps will only work best with Realistic-based shading.
+- **Detail Maps**: This texture slot will not be carried over as we use a far more advanced setup in both [Details](/color-and-normals/details.md) and [RGBA Color Masking](/color-and-normals/rgba-color-masking.md).
+- **Detail Albedo x2**: This texture slot will not be carried over as we use a more advanced approach in [Details](/color-and-normals/details.md) feature.
 
 ## LilToon
 

--- a/versioned_docs/version-9.3/general/upgrade/v7-upgrade.md
+++ b/versioned_docs/version-9.3/general/upgrade/v7-upgrade.md
@@ -13,7 +13,7 @@ This page covers a few of the major differences between the two versions that sh
 
 ### Light Data
 
-**Ambient Occlusion** and **Direct Shadows** have been moved from a shading mode subsection to the [Light Data](/docs/shading/light-data.md) section. 
+**Ambient Occlusion** and **Direct Shadows** have been moved from a shading mode subsection to the [Light Data](/shading/light-data.md) section. 
 
 Various other settings have been moved to the Light Data section, including:
 
@@ -38,19 +38,19 @@ The "Toon" mode, with subsections for Toon Ramp, Math Gradient, and Shade Map, h
 
 #### Math Gradient -> Multilayer Math
 
-The Math Gradient mode has been reworked into a new mode called [Multilayer Math](/docs/shading/main.md#multilayer-math).
+The Math Gradient mode has been reworked into a new mode called [Multilayer Math](/shading/main.md#multilayer-math).
 
 The first shading layer is equivalent to the Math Gradient mode, with "Gradient Start" and "Gradient End" having been replaced by a shadow center point and a blur. Changing the center point is equivalent to changing the average of the "Gradient Start" and "Gradient End" settings, and changing the blur is equivalent to moving the "Gradient Start" and "Gradient End" settings closer or farther apart.
 
 ### Metallics/Metallics and Specular -> Reflections and Specular
 
-The "Metallics/Specular" and "Metallics (Deprecated)" sections have been removed, and PBR Reflections and Specular highlights have been re-worked significantly into the new [Reflections & Specular](/docs/shading/reflections-and-specular.md) module. A new inline packer has been introduced as well, which allow easy merging of Metallic and Smoothness Maps.
+The "Metallics/Specular" and "Metallics (Deprecated)" sections have been removed, and PBR Reflections and Specular highlights have been re-worked significantly into the new [Reflections & Specular](/shading/reflections-and-specular.md) module. A new inline packer has been introduced as well, which allow easy merging of Metallic and Smoothness Maps.
 
-By opening up the [Packed Maps](/docs/shading/reflections-and-specular.md#packed-maps) texture slot, you can insert individual maps into each channel. You can directly use metallic and smoothness/roughness maps, or you can use the inline packer to re-map your v7 maps to the new packed map. Put your v7 map texture in both the Metallic map and Smoothness map slots, and select `R` and `A` respectively to pull from the old metallic and smoothness channels. If you used the Reflectivity map, you can also put the v7 texture in the Reflection Mask slot and select `G`, but this may not have the intended effect due to the more accurate PBR implementation.
+By opening up the [Packed Maps](/shading/reflections-and-specular.md#packed-maps) texture slot, you can insert individual maps into each channel. You can directly use metallic and smoothness/roughness maps, or you can use the inline packer to re-map your v7 maps to the new packed map. Put your v7 map texture in both the Metallic map and Smoothness map slots, and select `R` and `A` respectively to pull from the old metallic and smoothness channels. If you used the Reflectivity map, you can also put the v7 texture in the Reflection Mask slot and select `G`, but this may not have the intended effect due to the more accurate PBR implementation.
 
 ### Specular Highlights 1/2 -> Stylized Specular/Anisotropics
 
-The custom specular highlights mode has been reworked into a new feature called [Stylized Reflections](/docs/shading/stylized-reflections.md), and Anisotropic reflections have been reworked into a new feature called [Anisotropics](/docs/shading/anisotropics.md).
+The custom specular highlights mode has been reworked into a new feature called [Stylized Reflections](/shading/stylized-reflections.md), and Anisotropic reflections have been reworked into a new feature called [Anisotropics](/shading/anisotropics.md).
 
 ## Color & Normals
 
@@ -58,13 +58,13 @@ The custom specular highlights mode has been reworked into a new feature called 
 
 Basic Emission has been removed as it was often used incorrectly.
 
-If you have a material that should always have a minimum brightness, use the [Min Brightness](/docs/shading/light-data.md#min-brightness) setting in the Light Data section.
+If you have a material that should always have a minimum brightness, use the [Min Brightness](/shading/light-data.md#min-brightness) setting in the Light Data section.
 
-If you need a material to have a uniform emission, use an Emission slot with [Use Base Colors](/docs/special-fx/emission.md#use-base-colors) enabled, and a white color. This will make the `Emission Strength` setting equivalent to the old "Basic Emission" setting.
+If you need a material to have a uniform emission, use an Emission slot with [Use Base Colors](/special-fx/emission.md#use-base-colors) enabled, and a white color. This will make the `Emission Strength` setting equivalent to the old "Basic Emission" setting.
 
 ### Alpha Options
 
-The Alpha options has been reworked, with Distance Alpha (Distance Fade), Fresnel Alpha, and Angular Alpha being moved to [Alpha Options](/docs/color-and-normals/alpha-options.md).
+The Alpha options has been reworked, with Distance Alpha (Distance Fade), Fresnel Alpha, and Angular Alpha being moved to [Alpha Options](/color-and-normals/alpha-options.md).
 
 ## Outlines
 
@@ -76,13 +76,13 @@ However, in V8.x versions, Outlines were moved to their own versions such as `.p
 
 ### Emission
 
-"Glow In The Dark" was renamed to [Light Based](/docs/special-fx/emission.md#light-based) in order to better describe the effect. It can still be used in the same way.
+"Glow In The Dark" was renamed to [Light Based](/special-fx/emission.md#light-based) in order to better describe the effect. It can still be used in the same way.
 
 "Multiply Emission Strength" was removed from emission audio link, as it conflicted with (and was less useful than) the X/Y min/max additive values. To recreate its effect, set the "Min" value of Emission Add to the negative value of your base emission strength, and the "Max" value of Emission Add to zero. In Worlds with AudioLink, this will result in no emission when there's no volume in the selected channel, and the base emission value when there is max volume in that channel.
 
 ### Dissolve
 
-"Dissolve Noise" was renamed to [Dissolve Gradient](/docs/special-fx/dissolve.md#dissolve-gradient), and "Dissolve Detail Noise" was renamed to [Dissolve Noise](/docs/special-fx/dissolve.md#dissolve-noise). This better reflects their functionality
+"Dissolve Noise" was renamed to [Dissolve Gradient](/special-fx/dissolve.md#dissolve-gradient), and "Dissolve Detail Noise" was renamed to [Dissolve Noise](/special-fx/dissolve.md#dissolve-noise). This better reflects their functionality
 
 If you only have one dissolve map, it should be put in the `Dissolve Gradient` slot.
 
@@ -100,4 +100,4 @@ To configure the behavior of Panosphere UVs, see the `Panosphere` section locate
 
 ### Parallax/Parallax Heightmapping
 
-Parallax/Parallax Heightmapping have been reworked to use the new UV option system, in [Parallax Heighmapping](/docs/modifiers/uvs/parallax.md). Similar to the Panosphere option, the parallax-modified UV can be applied to almost any texture in the shader, by modifying one of the base UV slots (0, 1, 2, 3).
+Parallax/Parallax Heightmapping have been reworked to use the new UV option system, in [Parallax Heighmapping](/modifiers/uvs/parallax.md). Similar to the Panosphere option, the parallax-modified UV can be applied to almost any texture in the shader, by modifying one of the base UV slots (0, 1, 2, 3).

--- a/versioned_docs/version-9.3/intro.md
+++ b/versioned_docs/version-9.3/intro.md
@@ -49,7 +49,7 @@ Please join the [Poiyomi Shaders Discord <FAIcon icon="fa-solid fa-square-arrow-
 
 All information in this documentation is geared towards `9.0` and newer. Therefore, this documentation may not apply at all if you are using an older version.
 
-If you are on an older version of Poiyomi Shaders, we highly suggest that you read [**our upgrading guidelines**](/docs/general/upgrade/upgrade.md) in order to ensure you are fully up-to-date on the latest features that are documented here.
+If you are on an older version of Poiyomi Shaders, we highly suggest that you read [**our upgrading guidelines**](/general/upgrade/upgrade.md) in order to ensure you are fully up-to-date on the latest features that are documented here.
 
 ## Completion Status
 

--- a/versioned_docs/version-9.3/modifiers/blacklight-masking.md
+++ b/versioned_docs/version-9.3/modifiers/blacklight-masking.md
@@ -50,7 +50,7 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **One** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **One** effects onto.
 
 ## Two
 
@@ -75,7 +75,7 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **Two** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **Two** effects onto.
 
 ## Three
 
@@ -100,7 +100,7 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **Three** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **Three** effects onto.
 
 ## Four
 
@@ -125,4 +125,4 @@ The Gradient of the BlackLight Mask, ranging from Beginning to End Point.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply the BlackLight Mask **Four** effects onto.
+Select which [Global Mask](/modifiers/global-masks.md) to apply the BlackLight Mask **Four** effects onto.

--- a/versioned_docs/version-9.3/modifiers/global-masks.md
+++ b/versioned_docs/version-9.3/modifiers/global-masks.md
@@ -27,7 +27,7 @@ Each Global Mask uses the `Red (R)`, `Green (G)`, `Blue (B)`, and `Alpha (A)` ch
 
 Since you have a total of 4 Global Masking slots, each providing 4 Color Channels, you can have up to 16 Color Channels to use for your Masks.
 
-*Below is a video introduction to Global Masking, courtesy of community member Teeh. This also briefly covers it's sister feature [Global Themes](/docs/modifiers/global-themes.md) as well.*
+*Below is a video introduction to Global Masking, courtesy of community member Teeh. This also briefly covers it's sister feature [Global Themes](/modifiers/global-themes.md) as well.*
 
 <div class="videobox">
 <iframe class="iframe-element" src="https://www.youtube-nocookie.com/embed/ng780niVSzA?si=TO5iXVR7NWWw4xNw" title="YouTube Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
@@ -51,7 +51,7 @@ Once done, see how to use them in [Usage in the Shader](#usage-in-the-shader).
 
 ### Method 2: Provide your own Texture
 
-Another way of creating Global Masks is by the use of software, such as Substance 3D Painter, to pack your `User` channels into an `R + G + B + A` Texture way in advance. To do this, you would have to add the `User` channels and paint on those channels you specify. We offer an example Export Template that shows the usage of this, which you can download from [here](/docs/general/substance-painter.md).
+Another way of creating Global Masks is by the use of software, such as Substance 3D Painter, to pack your `User` channels into an `R + G + B + A` Texture way in advance. To do this, you would have to add the `User` channels and paint on those channels you specify. We offer an example Export Template that shows the usage of this, which you can download from [here](/general/substance-painter.md).
 
 After exporting your `t_$textureSet_GlobalMask.png` file, slot it directly into one of the Global Mask slots. See [Usage in the Shader](#usage-in-the-shader) below to see how to use them.
 
@@ -109,7 +109,7 @@ Texture Slot defining the forth Global Mask. This will represent Global Masks `4
 
 ## Vertex Colors
 
-This section allows you to use [Vertex Colors](/docs/vertex-options/vertex-colors.md) on your Mesh as a Global Mask.
+This section allows you to use [Vertex Colors](/vertex-options/vertex-colors.md) on your Mesh as a Global Mask.
 
 ### Linear Colors
 

--- a/versioned_docs/version-9.3/modifiers/global-themes.md
+++ b/versioned_docs/version-9.3/modifiers/global-themes.md
@@ -43,7 +43,7 @@ Color to use for Theme Color.
 
 How much to shift the Theme Color around the Hue Circle. This value is circular, and will have the same result at 0 and 1.
 
-This functions in the same fashion as Color Adjust's [Hue Shift](/docs/color-and-normals/color-adjust.md#hue-shift-1) slider.
+This functions in the same fashion as Color Adjust's [Hue Shift](/color-and-normals/color-adjust.md#hue-shift-1) slider.
 
 ### Hue Adjust Speed
 

--- a/versioned_docs/version-9.3/modifiers/uvs/distortion-uv.md
+++ b/versioned_docs/version-9.3/modifiers/uvs/distortion-uv.md
@@ -56,7 +56,7 @@ Sets the strength of the Distortion from Texture 2.
 ### Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 #### Strength 1 Band

--- a/versioned_docs/version-9.3/modular-shader-system/modular-shader-system.md
+++ b/versioned_docs/version-9.3/modular-shader-system/modular-shader-system.md
@@ -10,7 +10,7 @@ Poiyomi Shaders is put together using the Modular Shader System, which allows fo
 :::info Attention Shader Developers
 For security reasons, the Modular Shader components and modules referenced here are only exposed for end-user access in the Poiyomi Pro shader package, as it also exposes Pro-only modules.
 
-To learn more on how to obtain the Poiyomi Pro version, see [Download & Install: Poiyomi Pro](/docs/download/download.md#poiyomi-pro).
+To learn more on how to obtain the Poiyomi Pro version, see [Download & Install: Poiyomi Pro](/download/download.md#poiyomi-pro).
 :::
 
 ## Overview

--- a/versioned_docs/version-9.3/outlines/outlines.md
+++ b/versioned_docs/version-9.3/outlines/outlines.md
@@ -137,7 +137,7 @@ Determines if you want the Outlines to blend in a way that is similar to Unity-C
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Enables the ability to modify the Outline Color in a similar fashion to [Color Adjust](/docs/color-and-normals/color-adjust.md). This is applied directly after the main [Outline Color](#color), and will not affect other sections that modify the base Outline Color.
+Enables the ability to modify the Outline Color in a similar fashion to [Color Adjust](/color-and-normals/color-adjust.md). This is applied directly after the main [Outline Color](#color), and will not affect other sections that modify the base Outline Color.
 
 :::info This area was recently updated!
 All of these values can be individually animated as of the latest version.
@@ -302,7 +302,7 @@ If enabled, will invert the value from the [Outline Mask Channel](#outline-mask-
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`R`/`G`/`B`/`A`
 
-Which [Vertex Color](/docs/vertex-options/vertex-colors.md) channel to use to control the Outline Z Offset.
+Which [Vertex Color](/vertex-options/vertex-colors.md) channel to use to control the Outline Z Offset.
 
 ### Vertex Color Strength
 
@@ -372,7 +372,7 @@ Sets how the Outline Stencil should test the depth buffer. By default, the depth
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 <ReactVideo src='/vid/outlines/outlineALtest4.mp4'/>

--- a/versioned_docs/version-9.3/rendering/blending.md
+++ b/versioned_docs/version-9.3/rendering/blending.md
@@ -5,12 +5,12 @@ description: Blending defines how the shader should blend on top of pixels that 
 keywords: [blending, render, rendering, poiyomi, shader]
 ---
 
-The Blending section defines how the shader should blend on top of pixels that are already drawn. These options are set by the [Rendering Preset](/docs/general/render-preset.md) selected at the top of the shader, and almost always need not be set manually.
+The Blending section defines how the shader should blend on top of pixels that are already drawn. These options are set by the [Rendering Preset](/general/render-preset.md) selected at the top of the shader, and almost always need not be set manually.
 
 These blend options are exposed separately for the base pass and the add pass, as the add pass needs to blend on top of the base pass.
 
 :::note Documentation Info
-Outline Blending will also be visible here containing the same settings as described here. This allows you to control the Blending operator of the [Outlines](/docs/outlines/outlines.md) separate from the base Blending.
+Outline Blending will also be visible here containing the same settings as described here. This allows you to control the Blending operator of the [Outlines](/outlines/outlines.md) separate from the base Blending.
 :::
 
 ## RGB Blend Op
@@ -23,13 +23,13 @@ Which blend operator to use for the RGB channels. This is almost always set to `
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ## RGB Destination Blend
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ## Advanced Alpha Blending
 
@@ -45,10 +45,10 @@ What blend op to use for the Alpha channel. This is typically set by the Renderi
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha source. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.
 
 ### Alpha Destination Blend
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Zero`/`One`/`DstColor`/`SrcColor`/`OneMinusDstColor`/`SrcAlpha`/`OneMinusSrcColor`/`DstAlpha`/`OneMinusDstAlpha`/`SrcAlphaSaturate`/`OneMinusSrcAlpha`
 
-Which blend factors to use for the Alpha destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/docs/general/render-preset.md) page for more information.
+Which blend factors to use for the Alpha destination. See the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Blend.html) and [Rendering Presets](/general/render-preset.md) page for more information.

--- a/versioned_docs/version-9.3/rendering/rendering.md
+++ b/versioned_docs/version-9.3/rendering/rendering.md
@@ -8,7 +8,7 @@ keywords: [render, rendering, cull, culling, ztest, zwrite, z, offset, instancin
 The Rendering section provides various low-level options for controlling how the shader is rendered. This plays an important part in how the Graphics Driver will interpret the shader at runtime.
 
 :::info
-Many of the settings in this section are automatically-configured depending on which [Rendering Preset](/docs/general/render-preset.md) you select.
+Many of the settings in this section are automatically-configured depending on which [Rendering Preset](/general/render-preset.md) you select.
 :::
 
 ## Cull
@@ -34,7 +34,7 @@ Learn more at [Unity's Documentation <FAIcon icon="fa-solid fa-square-arrow-up-r
 ## ZWrite
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`On`
-  - Default: Determined by [Rendering Preset](/docs/general/render-preset.md)
+  - Default: Determined by [Rendering Preset](/general/render-preset.md)
 
 Determines whether the shader should write to the depth buffer. For Opaque presets, this is usually `On`, but for Transparent presets, this is usually `Off`.
 
@@ -150,7 +150,7 @@ To do this, open the Action Menu, go to `Tools -> Avatar` and toggle the `Fallba
 The Render Queue tells Unity to set the sorting behavior within the Rendering Pipeline, as Unity must sort and draw objects within the Scene so that it can be show to the Camera as requested by the Render Queue. This plays a vital part on how the shader is rendered in-game.
 
 :::danger
-**This setting is automatically set by the [Rendering Preset](/docs/general/render-preset.md) and should not be touched!**
+**This setting is automatically set by the [Rendering Preset](/general/render-preset.md) and should not be touched!**
 
 Only modify this value if you *absolutely* know what you are doing.
 :::

--- a/versioned_docs/version-9.3/rendering/stencil.md
+++ b/versioned_docs/version-9.3/rendering/stencil.md
@@ -10,7 +10,7 @@ The Stencil section gives access to the Stencil buffer and it's associated capab
 To learn more about Stencils, visit the [Unity Documentation <FAIcon icon="fa-solid fa-square-arrow-up-right"/>](https://docs.unity3d.com/Manual/SL-Stencil.html).
 
 :::note Documentation info
-Outline Stencil will also be visible here containing the same settings as described below. This allows you to control the Stencil behavior of the [Outlines](/docs/outlines/outlines.md) separate from the base Stencil.
+Outline Stencil will also be visible here containing the same settings as described below. This allows you to control the Stencil behavior of the [Outlines](/outlines/outlines.md) separate from the base Stencil.
 :::
 
 ## Stencil Type

--- a/versioned_docs/version-9.3/shading/light-data.md
+++ b/versioned_docs/version-9.3/shading/light-data.md
@@ -5,7 +5,7 @@ description: Light Data provides technical properties that change how Lighting a
 keywords: [light, data, light data, lighting, shading, ao, shadow, mapping, masks, color, grayscale, directional, influence, poiyomi, shader]
 ---
 
-The Light Data section provides options for changing features relating to the data used for lighting and shading the material. Options here significantly influence the functionality of the [Shading](/docs/shading/main.md) section.
+The Light Data section provides options for changing features relating to the data used for lighting and shading the material. Options here significantly influence the functionality of the [Shading](/shading/main.md) section.
 
 ## AO Maps
 
@@ -18,7 +18,7 @@ The AO map texture reads all 4 RGBA channels independently, allowing different A
 Generally, if only a single map is being used (such as in the case of a black and white AO map), only one slider should generally be used. 
 
 :::note
-AO Maps are more effective in Realistic-based lighting methods (see [Shading](/docs/shading/main.md)). It may not be visible in Toon-based lighting.
+AO Maps are more effective in Realistic-based lighting methods (see [Shading](/shading/main.md)). It may not be visible in Toon-based lighting.
 :::
 
 ### AO Map R/G/B/A Strength

--- a/versioned_docs/version-9.3/shading/ltcgi.md
+++ b/versioned_docs/version-9.3/shading/ltcgi.md
@@ -19,7 +19,7 @@ For more detailed information on this system, [visit the LTCGI Documentation <FA
 This checkbox allows toggling LTCGI effects at runtime.
 
 :::tip
-LTCGI rendering is enabled by default. To turn off LTCGI in-game, you need to animate this Toggle (checkbox) when creating toggles for LTCGI on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+LTCGI rendering is enabled by default. To turn off LTCGI in-game, you need to animate this Toggle (checkbox) when creating toggles for LTCGI on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## Diffuse Tint
@@ -39,7 +39,7 @@ Color to blend multiplicatively with LTCGI to tint the reflection. Use shades of
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
   - Default: `On`
 
-When enabled, will sample the metallicity and smoothness values from [Reflections & Specular](/docs/shading/reflections-and-specular.md) for LTCGI.
+When enabled, will sample the metallicity and smoothness values from [Reflections & Specular](/shading/reflections-and-specular.md) for LTCGI.
 
 :::info
 If **Reflections & Specular** module is turned off, the **Metallic** and **Smoothness** sliders will appear below and serve as a fallback.

--- a/versioned_docs/version-9.3/shading/main.md
+++ b/versioned_docs/version-9.3/shading/main.md
@@ -6,7 +6,7 @@ keywords: [shading, diffuse, lighting, base, style, stylized, base pass, add pas
 toc_max_heading_level: 3
 ---
 
-The **Shading** section defines the base shading of the material. It controls how the material reflects light in a diffuse way, and how it is affected by other lighting. Options in the [Light Data](/docs/shading/light-data.md) section heavily affect how shading is performed.
+The **Shading** section defines the base shading of the material. It controls how the material reflects light in a diffuse way, and how it is affected by other lighting. Options in the [Light Data](/shading/light-data.md) section heavily affect how shading is performed.
 
 <a>
 <img src="/img/shading/Shading_All.png" alt="Various Shading Styles on multiple Material Spheres."/>
@@ -666,7 +666,7 @@ Smoothness is a baked-in value determining how much additional reflection the ma
 Cloth shading is a physically-based lighting model that draws from the Cloth shading model used in [Google's Filament engine](https://google.github.io/filament/Materials.html#materialmodels/clothmodel). It uses a packed mask to determine physically-based components of the lighting.
 
 :::info Cloth PBR is Built-In
-Cloth shading has Reflections & Specular already built-in. Therefore, it's <u>not necessary</u> to use both Cloth shading and [Reflections & Specular](/docs/shading/reflections-and-specular.md) at the same time!
+Cloth shading has Reflections & Specular already built-in. Therefore, it's <u>not necessary</u> to use both Cloth shading and [Reflections & Specular](/shading/reflections-and-specular.md) at the same time!
 :::
 
 <details>
@@ -751,7 +751,7 @@ This value is multiplied with the value of the Smoothness Map. If no smoothness 
 SDF (Signed Distance Field) is a complex shading style that defines how shadows should act based on the direction of light. This can create cell-looking shadows in a way similar to how Mihoyoverse renders their models (Genshin Impact, Zenless Zone Zero, etc.)
 
 :::warning SDF is NOT universal
-In a similar fashion to having a [Shadow Map](/docs/shading/light-data.md#shadow-map), SDF requires a specialized data texture, specific to your model, in order for the appearance of SDF to appear as intended.
+In a similar fashion to having a [Shadow Map](/shading/light-data.md#shadow-map), SDF requires a specialized data texture, specific to your model, in order for the appearance of SDF to appear as intended.
 
 Therefore, the results will appear "flat" if there is no texture defined.
 :::
@@ -848,10 +848,10 @@ Makes the Add Pass Lighting match close to your [Lighting Type (Base Pass)](#lig
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-If set, will send the Lighting data to a [Global Mask](/docs/modifiers/global-masks.md) of your choice as a mask. This will make the data written to the Global Mask appear based on it's illumination from the environment.
+If set, will send the Lighting data to a [Global Mask](/modifiers/global-masks.md) of your choice as a mask. This will make the data written to the Global Mask appear based on it's illumination from the environment.
 
 ### Inversed LightMap to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-If set, will send inverted Lighting data to a [Global Mask](/docs/modifiers/global-masks.md) of your choice as a mask. This is similar to the above option, but it will invert the data instead.
+If set, will send inverted Lighting data to a [Global Mask](/modifiers/global-masks.md) of your choice as a mask. This is similar to the above option, but it will invert the data instead.

--- a/versioned_docs/version-9.3/shading/matcap.md
+++ b/versioned_docs/version-9.3/shading/matcap.md
@@ -251,7 +251,7 @@ Enables hue shifting of the matcap texture.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -346,7 +346,7 @@ How much to Blend the result.
 Allows Audio Link to influence the Matcap.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Alpha Band

--- a/versioned_docs/version-9.3/shading/rim-lighting.md
+++ b/versioned_docs/version-9.3/shading/rim-lighting.md
@@ -185,7 +185,7 @@ Enables the Hue Shift feature in Rim Lighting.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -232,18 +232,18 @@ Controls how much to Apply the Rim to your Alpha.
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Choose to use a [Global Mask](/docs/modifiers/global-masks.md) to constrain the Rim Lighting to the specified Mask instead. Overrides [Mask & Bias](#mask--bias).
+Choose to use a [Global Mask](/modifiers/global-masks.md) to constrain the Rim Lighting to the specified Mask instead. Overrides [Mask & Bias](#mask--bias).
 
 ### Apply to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Allows you to add the currently set Rim Lighting setup to be applied to an existing [Global Mask](/docs/modifiers/global-masks.md) of your choice.
+Allows you to add the currently set Rim Lighting setup to be applied to an existing [Global Mask](/modifiers/global-masks.md) of your choice.
 
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 <ReactVideo src='/vid/shading/RL_AudioLink.mp4'/>

--- a/versioned_docs/version-9.3/shading/ssao.md
+++ b/versioned_docs/version-9.3/shading/ssao.md
@@ -27,7 +27,7 @@ SSAO is a performance heavy effect, so use it mindfully. Add a toggle for [Anima
 This checkbox allows toggling SSAO at runtime.
 
 :::tip
-SSAO rendering is enabled by default. To turn off SSAO in-game, you need to animate this Toggle (checkbox) when creating toggles for SSAO on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+SSAO rendering is enabled by default. To turn off SSAO in-game, you need to animate this Toggle (checkbox) when creating toggles for SSAO on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## AO Intensity
@@ -171,10 +171,10 @@ Reduce these if your AO looks like it's "reaching too far". X determines the dif
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to apply to SSAO.
+Select which [Global Mask](/modifiers/global-masks.md) to apply to SSAO.
 
 ### Apply To Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) SSAO writes to.
+Select which [Global Mask](/modifiers/global-masks.md) SSAO writes to.

--- a/versioned_docs/version-9.3/shading/stylized-reflections.md
+++ b/versioned_docs/version-9.3/shading/stylized-reflections.md
@@ -7,7 +7,7 @@ toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---
 
-Stylized Reflections is a module that applies a stylized specular highlight or reflective effect to the material. It's useful for creating a more toon-like, stylized effect than the standard specular highlights or reflections from [Reflections & Specular](/docs/shading/reflections-and-specular.md).
+Stylized Reflections is a module that applies a stylized specular highlight or reflective effect to the material. It's useful for creating a more toon-like, stylized effect than the standard specular highlights or reflections from [Reflections & Specular](/shading/reflections-and-specular.md).
 
 :::info Changes in 9.1
 All features of the previously-named module, Stylized Specular, was merged into the [UnityChan](#unity-chan-specular) Mode documented below.

--- a/versioned_docs/version-9.3/special-fx/constellation.md
+++ b/versioned_docs/version-9.3/special-fx/constellation.md
@@ -115,13 +115,13 @@ Mask texture that limits where the constellation should only appear in. Black is
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Uses a [Global Mask](/docs/modifiers/global-masks.md) to limit where the constellation should only appear in.
+Uses a [Global Mask](/modifiers/global-masks.md) to limit where the constellation should only appear in.
 
 ## Write to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-If set, constellations will write onto the selected [Global Mask](/docs/modifiers/global-masks.md) channel.
+If set, constellations will write onto the selected [Global Mask](/modifiers/global-masks.md) channel.
 
 ## Random Colors
 
@@ -148,7 +148,7 @@ Sets the range of value/brightness to apply to the constellations at random inte
 Enables Audio Link features on Constellation.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Emission Band

--- a/versioned_docs/version-9.3/special-fx/dissolve.md
+++ b/versioned_docs/version-9.3/special-fx/dissolve.md
@@ -102,7 +102,7 @@ A color tint blended multiplicative with the dissolved texture.
 :::tip
 If you set the Alpha channel of this color to `A = 0`, the Dissolve can transition from the base color to Transparency.
 
-**Keep in mind this only works if you set your [Rendering Preset](/docs/general/render-preset.md) to Cutout or a Transparent Preset.**
+**Keep in mind this only works if you set your [Rendering Preset](/general/render-preset.md) to Cutout or a Transparent Preset.**
 :::
 
 <ReactVideo src='/vid/special-fx/Dissolve_DissolvedColor.mp4'/>
@@ -180,19 +180,19 @@ A black and white (single channel) mask that controls where to apply the dissolv
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use as the Dissolve Mask instead.
+Select which [Global Mask](/modifiers/global-masks.md) to use as the Dissolve Mask instead.
 
 ### Dissolved to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-This allows you to select which [Global Mask](/docs/modifiers/global-masks.md) to affect when it is fully Dissolved.
+This allows you to select which [Global Mask](/modifiers/global-masks.md) to affect when it is fully Dissolved.
 
 ### Undissolved to Global Mask
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-This allows you to select which [Global Mask](/docs/modifiers/global-masks.md) to affect when it is NOT Dissolved whatsoever.
+This allows you to select which [Global Mask](/modifiers/global-masks.md) to affect when it is NOT Dissolved whatsoever.
 
 ### VertexColor Mask
 
@@ -223,7 +223,7 @@ At a value of 1, the dissolve will complete a full cycle (from `0` to `1` to `0`
 Enables Audio Link to control Dissolve.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Dissolve Alpha Band
@@ -396,7 +396,7 @@ Enables/Disables hue shifting features for dissolve. Unlike most sections, this 
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -437,7 +437,7 @@ Enables or disables hue shifting of the the dissolve edge color.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Edge Select or Shift
 
@@ -475,7 +475,7 @@ Allows an alternative way to use UV Tile Discard with the use of Dissolve's effe
 If you prefer to use UV Tile Discard in a way that allows a sleek animation transition, this is the section to do it.
 
 :::info Refer to UV Tile Documentation
-All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
+All the sliders listed for each Row will reflect the same locations as described in [UV Tile Discard](/special-fx/uv-tile-discard.md). Please refer to the documentation page to see what they are.
 
 Each Slider will control the [Dissolve Alpha](#dissolve-alpha) for the described Row and Column.
 :::
@@ -497,7 +497,7 @@ Enforces the Dissolve Tiles to be discarded once a UV Tile Dissolve reaches `1` 
 
 - `Type`: <PropertyIcon name="floatrange" />**Float**, Range: `-1.0 - 1.0`
 
-This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/docs/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
+This property will appear for each Row and Column for UV Tile Dissolve. Below is a table reference matching the same positions as described in [UV Tile Discard](/special-fx/uv-tile-discard.md), named to each field shown in UV Tile Dissolve.
 
 |  | Column 0 | Column 1 | Column 2 | Column 3 |
 | :---: | :---: | :---: | :---: | :---: |

--- a/versioned_docs/version-9.3/special-fx/emission.md
+++ b/versioned_docs/version-9.3/special-fx/emission.md
@@ -31,7 +31,7 @@ Please be aware that Fallback Shaders do not support Masking. If you are using *
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use as the Emission Mask instead.
+Select which [Global Mask](/modifiers/global-masks.md) to use as the Emission Mask instead.
 
 Expand the **Emission Mask** slot from above to see this property.
 
@@ -107,7 +107,7 @@ Enables hue shifting of the emission.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -289,7 +289,7 @@ An offset applied to the wave. This value is unit-less, and depends on the veloc
 Enables or disables Emission Audio Link features.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Strength Multiplier

--- a/versioned_docs/version-9.3/special-fx/flipbook.md
+++ b/versioned_docs/version-9.3/special-fx/flipbook.md
@@ -43,7 +43,7 @@ Defines where on the UV the flipbook can be applied. Black indicates the flipboo
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use for the Flipbook overall.
+Select which [Global Mask](/modifiers/global-masks.md) to use for the Flipbook overall.
 
 :::note
 Expand the **Mask** slot to see this property.
@@ -74,7 +74,7 @@ Optional setting to control if the Color and/or Alpha of the Flipbook should rep
 Replaces the base color with the Flipbook.
 
 :::tip
-You may animate this slider to toggle the Flipbook on the Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+You may animate this slider to toggle the Flipbook on the Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ## Emission Strength
@@ -183,7 +183,7 @@ Enable or Disable the Hue Shifting functionality.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -217,7 +217,7 @@ This value is circular, and will have the same result at 0 and 1.
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Scale Band

--- a/versioned_docs/version-9.3/special-fx/glitter.md
+++ b/versioned_docs/version-9.3/special-fx/glitter.md
@@ -245,7 +245,7 @@ Increasing this value will scale the brightness of the glitter based on the inte
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `Off`/`1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Select which [Global Mask](/docs/modifiers/global-masks.md) to use to mask the Glitter effects.
+Select which [Global Mask](/modifiers/global-masks.md) to use to mask the Glitter effects.
 
 ## Hue Shift
 
@@ -259,7 +259,7 @@ Enables or Disables the Hue Shift effect for glitter.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 
@@ -295,7 +295,7 @@ How much to shift the base color around the hue circle. This value is circular, 
 Enables or Disables Audio Link effects for Glitter.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Alpha Band

--- a/versioned_docs/version-9.3/special-fx/internal-parallax.md
+++ b/versioned_docs/version-9.3/special-fx/internal-parallax.md
@@ -103,7 +103,7 @@ Enables the Hue Shift feature of the Internal Parallax.
 
 Choice of Color Space to use for the Hue Shift. By default, it will be set to `OKLab`.
 
-Learn about the difference of Color Spaces as documented here in [Color Adjust](/docs/color-and-normals/color-adjust.md#oklab-vs-hsv).
+Learn about the difference of Color Spaces as documented here in [Color Adjust](/color-and-normals/color-adjust.md#oklab-vs-hsv).
 
 ### Select or Shift
 

--- a/versioned_docs/version-9.3/special-fx/pathing.md
+++ b/versioned_docs/version-9.3/special-fx/pathing.md
@@ -72,7 +72,7 @@ If enabled, multiplies the base alpha of the material with the Path's final alph
 
 Defines the gradients for the path. If using `Split Channels` mode, this texture should consist of between 1 and 4 channels of gradient data, with each channel representing a different path. Each channel used will flow between a value of `1` to a value of `255` (in 0-255 range), and should be defined from linear textures. 
 
-When expanded, 4 slots will be visible, one for each path. This is an integrated [Thry Texture Packer](/docs/thryeditor/thryeditor.md#texture-packer), which you can use to define gradient paths for each channel.
+When expanded, 4 slots will be visible, one for each path. This is an integrated [Thry Texture Packer](/thryeditor/thryeditor.md#texture-packer), which you can use to define gradient paths for each channel.
 
 If using `Merged Channels` mode, this texture should be the output of the Poiyomi Pathing tool. The 4 channels will be sampled in order, from `R -> G -> B -> A`.
 
@@ -202,7 +202,7 @@ Adjusts the mapping range of the specified Path.
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 For any audio link values with a **Vector2** offset, the **X** represents the value to add when the audio is at minimum (no audio), and the **Y** represents the value to add when the audio is at maximum (full audio).

--- a/versioned_docs/version-9.3/special-fx/proximity-color.md
+++ b/versioned_docs/version-9.3/special-fx/proximity-color.md
@@ -50,5 +50,5 @@ Distance from the camera at which the [Max Color](#max-color) should be applied.
 If enabled, applies the above set [Min Color](#min-color) to show on the Back Face, as if the Camera is going inside the mesh.
 
 :::caution Disable Culling for this setting to work
-In order to use **Force BackFace Color**, you must set the [Cull](/docs/rendering/rendering.md#cull) to `Off` under your [Rendering](/docs/rendering/rendering.md) settings.
+In order to use **Force BackFace Color**, you must set the [Cull](/rendering/rendering.md#cull) to `Off` under your [Rendering](/rendering/rendering.md) settings.
 :::

--- a/versioned_docs/version-9.3/special-fx/truchet.md
+++ b/versioned_docs/version-9.3/special-fx/truchet.md
@@ -97,7 +97,7 @@ If enabled, will override the Alpha/Transparency from the Base, if Transparency 
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Hide When No AL

--- a/versioned_docs/version-9.3/special-fx/uv-tile-discard.md
+++ b/versioned_docs/version-9.3/special-fx/uv-tile-discard.md
@@ -52,11 +52,11 @@ When a box is checked, that tile is discarded. When animating these Toggle check
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Face Discard is a granular alternative to the [Cull](/docs/rendering/rendering.md#cull) rendering option, providing control over which faces of a mesh to discard. It utilizes the pixel mode of UV Tile Discard to apply face discarding selectively, instead of applying global face culling across the entire material.
+Face Discard is a granular alternative to the [Cull](/rendering/rendering.md#cull) rendering option, providing control over which faces of a mesh to discard. It utilizes the pixel mode of UV Tile Discard to apply face discarding selectively, instead of applying global face culling across the entire material.
 
 This is useful when some backfaces are visible, such as in exposed interior areas of clothing, while others are not and can be discarded to improve performance. Using Face Discard in these cases lets you achieve performance gains without the limitations of enabling global culling.
 
-However, it’s important to note that while Face Discard provides more granular control compared to traditional face culling, it does not offer the same level of performance improvement as the global [Cull](/docs/rendering/rendering.md#cull) render option, which should be used when possible. This is due the discarding being performed in the fragment shader.
+However, it’s important to note that while Face Discard provides more granular control compared to traditional face culling, it does not offer the same level of performance improvement as the global [Cull](/rendering/rendering.md#cull) render option, which should be used when possible. This is due the discarding being performed in the fragment shader.
 
 ### Face Discard UV
 

--- a/versioned_docs/version-9.3/special-fx/voronoi.md
+++ b/versioned_docs/version-9.3/special-fx/voronoi.md
@@ -41,7 +41,7 @@ Determines where to contain the Voronoi effects and where it should only appear 
 
 - `Type`: <PropertyIcon name="dropdown" />**Dropdown**, Options: `1R`/`1G`/`1B`/`1A`/`2R`/`2G`/`2B`/`2A`/`3R`/`3G`/`3B`/`3A`/`4R`/`4G`/`4B`/`4A`
 
-Same as above, but uses a [Global Mask](/docs/modifiers/global-masks.md) instead to determine the Mask.
+Same as above, but uses a [Global Mask](/modifiers/global-masks.md) instead to determine the Mask.
 
 ## Noise
 
@@ -124,7 +124,7 @@ Minimum and Maximum range of Brightness to apply to each randomized Voronoi Cell
 ## Audio Link
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Inner Emission Band

--- a/versioned_docs/version-9.3/thryeditor/presets.md
+++ b/versioned_docs/version-9.3/thryeditor/presets.md
@@ -75,7 +75,7 @@ Once you reach this part, you are now ready to start marking properties on the M
 
 ### Tagging Preset Properties
 
-In a similar manner to [Marking Properties as Animated](/docs/general/locking.md#marking-properties-for-animation), `Right-Click` and in the context menu you will instead click `Is part of preset`. When you do this, a Light Blue colored `P` symbol will appear to the left next to it. This indicates that the property will be used in your Preset. Do this for each Property that you wish to use in your Preset.
+In a similar manner to [Marking Properties as Animated](/general/locking.md#marking-properties-for-animation), `Right-Click` and in the context menu you will instead click `Is part of preset`. When you do this, a Light Blue colored `P` symbol will appear to the left next to it. This indicates that the property will be used in your Preset. Do this for each Property that you wish to use in your Preset.
 
 <a>
 <img src="/img/thryeditor/Thry_MarkingPresets.png" alt="Tagging Properties as part of the Preset" width="400px"/>
@@ -88,7 +88,7 @@ Once you finish marking your Properties as `P`, test it out by going to a Materi
 Just like as described in [Using Presets](#using-presets), open the Preset List by pressing the **Presets** button, and your Preset should be seen in there. Select your Preset and Apply to your Material. That's it!
 
 :::warning
-Be careful when creating too many Preset Materials in your project. Otherwise, you may risk causing the [64 Slot Crash](/docs/general/textures-64-texture-slot-crash.md)!
+Be careful when creating too many Preset Materials in your project. Otherwise, you may risk causing the [64 Slot Crash](/general/textures-64-texture-slot-crash.md)!
 
 To help counteract against this, you can safely switch your Preset Material(s) to the Standard shader. Don't worry, your preset settings are preserved on the Material (.mat) file. So if you need to edit your presets again later on, simply switch it back to Poiyomi and your settings will appear exactly where you left it.
 :::

--- a/versioned_docs/version-9.3/thryeditor/settings.md
+++ b/versioned_docs/version-9.3/thryeditor/settings.md
@@ -67,7 +67,7 @@ Enabled by default, ThryEditor will attempt to automatically mark properties as 
 - `Setting`: **Toggle**
   - Default: `Off`
 
-Allows a custom suffix to be used on properties that are marked Renamed Animated (`RA`), overriding the default naming as outlined [here](/docs/general/locking.md#rename-animated).
+Allows a custom suffix to be used on properties that are marked Renamed Animated (`RA`), overriding the default naming as outlined [here](/general/locking.md#rename-animated).
 
 ### Gradient Save File Names
 

--- a/versioned_docs/version-9.3/thryeditor/thryeditor.md
+++ b/versioned_docs/version-9.3/thryeditor/thryeditor.md
@@ -48,7 +48,7 @@ Right Clicking opens the Quick Presets context menu. Here you can only select on
 
 *Right-Click the Presets button to quickly select a Preset.*
 
-You can also create your own Presets using this feature. [See the Documentation Page to learn more.](/docs/thryeditor/presets.md)
+You can also create your own Presets using this feature. [See the Documentation Page to learn more.](/thryeditor/presets.md)
 
 ### Material Linking
 
@@ -86,7 +86,7 @@ In each Texture Slot, a number will appear on the right-hand side of the Texture
 
 This number informs the user on how much Texture Memory (VRAM) that the assigned Texture is expected to consume. The amount indicated can greatly impact how other users load your Avatar's texture when it is being rendered on their end.
 
-To learn more about how Texture Memory impacts performance, [see this page](/docs/general/textures-and-colors.md#vram-usage).
+To learn more about how Texture Memory impacts performance, [see this page](/general/textures-and-colors.md#vram-usage).
 
 <a>
 <img src="/img/thryeditor/TextureVRAMText.png" alt="Estimated VRAM on the assigned Texture" width="700px"/>
@@ -98,7 +98,7 @@ Configurable in ThryEditor Settings, an asterisk (`*`) will appear next to a Mat
 
 ### VRChat Fallback Shader
 
-The Fallback Shader option generates a tag for the material that informs VRChat which shader to use when your shaders are hidden. See [Rendering: VRChat Fallback Shader](/docs/rendering/rendering.md#vrchat-fallback-shader) for more details.
+The Fallback Shader option generates a tag for the material that informs VRChat which shader to use when your shaders are hidden. See [Rendering: VRChat Fallback Shader](/rendering/rendering.md#vrchat-fallback-shader) for more details.
 
 <a>
 <img src="/img/thryeditor/fallback.png" alt="VRC Fallback Selector" width="700px"/>

--- a/versioned_docs/version-9.3/vertex-options/basics.md
+++ b/versioned_docs/version-9.3/vertex-options/basics.md
@@ -209,7 +209,7 @@ Determines the bottom lower height of the funnel.
 Enables the ability to manipulate the Vertex Options in response to Audio Link.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 <ReactVideo src='/vid/color-and-normals/VertexOptionsAudioLink.webm'/>

--- a/versioned_docs/version-9.3/vertex-options/glitching.md
+++ b/versioned_docs/version-9.3/vertex-options/glitching.md
@@ -75,7 +75,7 @@ Enables the ability to control the visibility of the glitching in mirrors.
 Enables the ability to use Audio Link to control the Glitching Intensity.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Glitch Band

--- a/versioned_docs/version-9.3/vertex-options/look-at.md
+++ b/versioned_docs/version-9.3/vertex-options/look-at.md
@@ -71,7 +71,7 @@ The following properties below will appear for each Color Mask you are customizi
 Controls the overall visibility of the LookAt effect. `0` would be no effect, `0.5` would be half of the effect, and `1.0` would be the full effect.
 
 :::tip
-Animate this slider when creating toggles for LookAt on this Material. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work!
+Animate this slider when creating toggles for LookAt on this Material. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work!
 :::
 
 ### Target Up Direction
@@ -138,7 +138,7 @@ Clamps the maximum rotational Roll of the affected mask on the Z-axis (Barrel Ro
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**WW
 
-Enables the visibility modifier, which includes features similar to the [Mirror/Camera Visibility](/docs/special-fx/mirror.md) feature. This can affect how LookAt appears either Normally, in the Mirror, or in the Camera.
+Enables the visibility modifier, which includes features similar to the [Mirror/Camera Visibility](/special-fx/mirror.md) feature. This can affect how LookAt appears either Normally, in the Mirror, or in the Camera.
 
 Use this section to specifically control how LookAt should appear in specific scenarios.
 
@@ -214,10 +214,10 @@ Mode to use for the LookAt visibility.
 
 - `Type`: <PropertyIcon name="toggle" />**Toggle**
 
-Enables [Audio Link](/docs/audio-link/audio-link.md) to control LookAt. This will affect ALL `Alpha` properties in LookAt.
+Enables [Audio Link](/audio-link/audio-link.md) to control LookAt. This will affect ALL `Alpha` properties in LookAt.
 
 :::info
-The settings in this section will only be visible when [Audio Link](/docs/audio-link/audio-link.md) is activated on the Material.
+The settings in this section will only be visible when [Audio Link](/audio-link/audio-link.md) is activated on the Material.
 :::
 
 ### Alpha Band

--- a/versioned_docs/version-9.3/vertex-options/vertex-colors.md
+++ b/versioned_docs/version-9.3/vertex-options/vertex-colors.md
@@ -7,7 +7,7 @@ keywords: [vertex, colors, vertex colors, linear, alpha, poiyomi, shader]
 
 The Vertex Colors section provides options for using a Mesh's Vertex Colors to affect the Base color and Alpha. Vertex Colors are determined by the embedded Color Attributes of a Mesh, which were painted on from 3D Software such as Blender.
 
-Vertex Colors can also be used as Masks in different parts of the Shader, such as [RGBA Color Masking](/docs/color-and-normals/rgba-color-masking.md#vertex-colors) and [Global Masks](/docs/modifiers/global-masks.md#vertex-colors).
+Vertex Colors can also be used as Masks in different parts of the Shader, such as [RGBA Color Masking](/color-and-normals/rgba-color-masking.md#vertex-colors) and [Global Masks](/modifiers/global-masks.md#vertex-colors).
 
 <ReactVideo src='/vid/color-and-normals/PoiVertexColors.webm'/>
 <em>This video shows how the shader will read Vertex Colors if the Mesh itself has assigned Color Attributes.</em>

--- a/versioned_docs/version-9.3/vertex-options/view-clip-prevention.md
+++ b/versioned_docs/version-9.3/vertex-options/view-clip-prevention.md
@@ -17,7 +17,7 @@ View Clip Prevention (also known as the [Uzumore Shader <FAIcon icon="fa-solid f
 This is used to globally toggle the Uzumore Shader's effect across the entire material.
 
 :::tip Reminder
-Make sure to tag this checkbox as animated if creating toggles for this feature. Animating the [Section Header](/docs/general/locking.md#section-header-checkboxes) will not work! [Read More](/docs/general/locking.md#marking-properties-for-animation)
+Make sure to tag this checkbox as animated if creating toggles for this feature. Animating the [Section Header](/general/locking.md#section-header-checkboxes) will not work! [Read More](/general/locking.md#marking-properties-for-animation)
 :::
 
 ## Push Amount (m)


### PR DESCRIPTION
This PR adds support for i18n to accomodate any future docs localization.

Changes:

- Added i18n to the docusaurus config
- Edited links to accomodate linking in i18n
- Fixed some links in 9.3 docs (due to name changes between versions)
- Added .idea to .gitignore so I don't push PhpStorm junk into repo :p

Files in /i18n/ru are autogenerated by docusaurus's write-localization function.

Editing links is necessary for localization, links that begin with /docs/ and etc will not properly resolve in localized environment, hence I had to remove /docs to have the project build and work properly 

(Docs ref for i18n markdown linking: https://docusaurus.io/docs/markdown-features/links)

Currently I have delibarately left out adding a language switch to navbar due to no actual translations being made, hence there will be no visible changes on the docs website for now.